### PR TITLE
Add CIFAR10 dataset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 cache:
   directories:
     - $TRAVIS_BUILD_DIR/mnist
+    - $TRAVIS_BUILD_DIR/cifar10
 branches:
   only:
     - master
@@ -26,6 +27,13 @@ before_install:
              -O http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz \
              -O http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
         gunzip *-ubyte.gz
+        cd -
+      fi
+      # Download CIFAR10 for tests if not loaded from cache
+      if find cifar10 -empty | read; then
+        mkdir cifar10
+        cd cifar10
+        curl http://www.cs.utoronto.ca/~kriz/cifar-10-python.tar.gz | tar xzf -
         cd -
       fi
       export FUEL_DATA_PATH=$PWD

--- a/fuel/datasets/__init__.py
+++ b/fuel/datasets/__init__.py
@@ -1,6 +1,7 @@
 from fuel.datasets.base import Dataset, InMemoryDataset
 
 from fuel.datasets.container import ContainerDataset
+from fuel.datasets.cifar10 import CIFAR10
 from fuel.datasets.mnist import MNIST
 from fuel.datasets.text import TextFile
 from fuel.datasets.billion import OneBillionWord

--- a/fuel/datasets/cifar10.py
+++ b/fuel/datasets/cifar10.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import os
+import cPickle
+
+import numpy
+
+from fuel import config
+from fuel.datasets import InMemoryDataset
+from fuel.schemes import SequentialScheme
+
+
+@InMemoryDataset.lazy_properties('features', 'targets')
+class CIFAR10(InMemoryDataset):
+    """The CIFAR10 dataset of natural images.
+
+    This dataset is a labeled subset of the ``80 million tiny images''
+    dataset [TINY]. It consists of 60,000 32 x 32 colour images in 10
+    classes, with 6,000 images per class. There are 50,000 training
+    images and 10,000 test images [CIFAR10].
+
+    .. [TINY] Antonio Torralba, Rob Fergus and William T. Freeman,
+       *80 million tiny images: a large dataset for non-parametric
+       object and scene recognition*, Pattern Analysis and Machine
+       Intelligence, IEEE Transactions on 30.11 (2008): 1958-1970.
+
+    .. [CIFAR10] Alex Krizhevsky, *Learning Multiple Layers of Features
+       from Tiny Images*, technical report, 2009.
+
+    .. todo::
+
+       Right now this dataset always returns flattened images. In order to
+       support e.g. convolutions and visualization, it needs to support the
+       original 32 x 32 x 3 image format.
+
+    Parameters
+    ----------
+    which_set : 'train' or 'test'
+        Whether to load the training set (50,000 samples) or the test set
+        (10,000 samples). Note that CIFAR10 does not have a validation
+        set; usually you will create your own training/validation split
+        using the start and stop arguments.
+    start : int, optional
+        The first example to load
+    stop : int, optional
+        The last example to load
+
+    """
+    provides_sources = ('features', 'targets')
+
+    def __init__(self, which_set, start=None, stop=None, **kwargs):
+        if which_set not in ('train', 'test'):
+            raise ValueError("CIFAR10 only has a train and test set")
+        if stop is None:
+            stop = 50000 if which_set == "train" else 10000
+        if start is None:
+            start = 0
+        self.num_examples = stop - start
+        self.default_scheme = SequentialScheme(self.num_examples, 1)
+        super(CIFAR10, self).__init__(**kwargs)
+
+        self.which_set = which_set
+        self.start = start
+        self.stop = stop
+
+    def load(self):
+        base_path = os.path.join(
+            config.data_path, 'cifar10', 'cifar-10-batches-py')
+        if self.which_set == 'train':
+            fnames = ['data_batch_%i' % i for i in xrange(1, 6)]
+            x = numpy.zeros((50000, 3072), dtype='float64')
+            y = numpy.zeros((50000, 1), dtype='uint8')
+            for i, fname in enumerate(fnames):
+                with open(os.path.join(base_path, fname)) as f:
+                    data = cPickle.load(f)
+                    x[10000 * i: 10000 * (i + 1)] = data['data']
+                    y[10000 * i: 10000 * (i + 1)] = numpy.asarray(
+                        data['labels'], dtype='uint8')[:, numpy.newaxis]
+            x = x[self.start: self.stop]
+            y = y[self.start: self.stop]
+        elif self.which_set == 'test':
+            with open(os.path.join(base_path, 'test_batch')) as f:
+                data = cPickle.load(f)
+                x = data['data'].astype('float64')[self.start: self.stop]
+                y = numpy.asarray(
+                    data['labels'], dtype='uint8')[self.start: self.stop,
+                                                   numpy.newaxis]
+        self.features = x
+        self.targets = y
+
+    def get_data(self, state=None, request=None):
+        if state is not None:
+            raise ValueError("CIFAR10 does not have a state")
+        return self.filter_sources((self.features[request],
+                                    self.targets[request]))

--- a/fuel/datasets/cifar10.py
+++ b/fuel/datasets/cifar10.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-import cPickle
 
 import numpy
+import six
+from six.moves import  cPickle, xrange
 
 from fuel import config
 from fuel.datasets import InMemoryDataset
@@ -70,16 +71,22 @@ class CIFAR10(InMemoryDataset):
             x = numpy.zeros((50000, 3072), dtype='float64')
             y = numpy.zeros((50000, 1), dtype='uint8')
             for i, fname in enumerate(fnames):
-                with open(os.path.join(base_path, fname)) as f:
-                    data = cPickle.load(f)
+                with open(os.path.join(base_path, fname), 'rb') as f:
+                    if six.PY3:
+                        data = cPickle.load(f, encoding='latin1')
+                    else:
+                        data = cPickle.load(f)
                     x[10000 * i: 10000 * (i + 1)] = data['data']
                     y[10000 * i: 10000 * (i + 1)] = numpy.asarray(
                         data['labels'], dtype='uint8')[:, numpy.newaxis]
             x = x[self.start: self.stop]
             y = y[self.start: self.stop]
         elif self.which_set == 'test':
-            with open(os.path.join(base_path, 'test_batch')) as f:
-                data = cPickle.load(f)
+            with open(os.path.join(base_path, 'test_batch'), 'rb') as f:
+                if six.PY3:
+                    data = cPickle.load(f, encoding='latin1')
+                else:
+                    data = cPickle.load(f)
                 x = data['data'].astype('float64')[self.start: self.stop]
                 y = numpy.asarray(
                     data['labels'], dtype='uint8')[self.start: self.stop,

--- a/tests/test_cifar10.py
+++ b/tests/test_cifar10.py
@@ -1,0 +1,26 @@
+import numpy
+from numpy.testing import assert_raises
+
+from fuel.datasets import CIFAR10
+
+
+def test_cifar10():
+    cifar10_train = CIFAR10('train', start=20000)
+    assert len(cifar10_train.features) == 30000
+    assert len(cifar10_train.targets) == 30000
+    assert cifar10_train.num_examples == 30000
+    cifar10_test = CIFAR10('test', sources=('targets',))
+    assert len(cifar10_test.features) == 10000
+    assert len(cifar10_test.targets) == 10000
+    assert cifar10_test.num_examples == 10000
+
+    first_feature, first_target = cifar10_train.get_data(request=[0])
+    assert first_feature.shape == (1, 3072)
+    assert first_feature.dtype.kind == 'f'
+    assert first_target.shape == (1, 1)
+    assert first_target.dtype is numpy.dtype('uint8')
+
+    first_target, = cifar10_test.get_data(request=[0, 1])
+    assert first_target.shape == (2, 1)
+
+    assert_raises(ValueError, CIFAR10, 'valid')


### PR DESCRIPTION
Based off `MNIST`, uses data that can currently be obtained through Pylearn2's `download_cifar10.sh` script.