### PR TITLE
Refactored lazy_properties

### DIFF
--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -192,10 +192,9 @@ class InMemoryDataset(Dataset):
     Datasets which hold data in memory must be treated differently when
     serializing (saving) the training progress, because it would be very
     inefficient to save the data along with the training process. Hence,
-    in-memory datasets support the :meth:`lazy_properties` decorator. This
-    decorator creates a series of properties whose values won't be
-    serialized; instead, their values will be reloaded (e.g. from disk) by
-    the :meth:`load` function after deserializing the object.
+    in-memory datasets support the :func:`do_not_pickle_properties`
+    decorator. Please see documentation there for more information why
+    the decorator is needed.
 
     If the files from which the data were loaded are no longer available,
     the de-serialization could fail. Hence the reloading of these
@@ -263,73 +262,76 @@ class InMemoryDataset(Dataset):
         """
         pass
 
-    @staticmethod
-    def lazy_properties(*lazy_properties):
-        r"""Decorator to assign lazy properties.
 
-        Used to assign "lazy properties" on :class:`InMemoryDataset`
-        classes.  Please see the documentation there for a discussion on
-        what lazy properties are and why they are needed.
+def do_not_pickle_properties(*lazy_properties):
+    r"""Decorator to assign non-pickable properties.
 
-        Parameters
-        ----------
-        \*lazy_properties : strings
-            The names of the attributes that are lazy.
+    Used to assign properties which will not be pickled on some class.
+    This decorator creates a series of properties whose values won't be
+    serialized; instead, their values will be reloaded (e.g. from disk) by
+    the :meth:`load` function after deserializing the object.
 
-        Notes
-        -----
-        The pickling behavior of the dataset is only overridden if the
-        dataset does not have a ``__getstate__`` method implemented.
+    The decorator can be used with :class:`InMemoryDataset` to avoid
+    serialization of bulky attributes. Other possible way of using the
+    decorator is with attributes which cannot be pickled at all. In this
+    case the user should construct the attribute himself in :meth:`load`.
 
-        Examples
-        --------
-        In order to make sure that attributes are not serialized with the
-        dataset, and are lazily reloaded by the
-        :meth:`~InMemoryDataset.load` method after deserialization, use the
-        decorator with the names of the attributes as an argument.
+    Parameters
+    ----------
+    \*lazy_properties : strings
+        The names of the attributes that are lazy.
 
-        >>> @InMemoryDataset.lazy_properties('features', 'targets')
-        ... class TestDataset(InMemoryDataset):
-        ...     def load(self):
-        ...         self.features = range(10 ** 6)
-        ...         self.targets = range(10 ** 6)[::-1]
+    Notes
+    -----
+    The pickling behavior of the dataset is only overridden if the
+    dataset does not have a ``__getstate__`` method implemented.
 
-        """
-        def lazy_property_factory(lazy_property):
-            """Create properties that perform lazy loading of attributes."""
-            def lazy_property_getter(self):
-                if not hasattr(self, '_' + lazy_property):
-                    self.load()
-                if not hasattr(self, '_' + lazy_property):
-                    raise ValueError("{} wasn't loaded".format(lazy_property))
-                return getattr(self, '_' + lazy_property)
+    Examples
+    --------
+    In order to make sure that attributes are not serialized with the
+    dataset, and are lazily reloaded after deserialization by the
+    :meth:`load` in the wrapped class. Use the decorator with the names of
+    the attributes as an argument.
 
-            def lazy_property_setter(self, value):
-                setattr(self, '_' + lazy_property, value)
+    >>> @do_not_pickle_properties('features', 'targets')
+    ... class TestDataset(InMemoryDataset):
+    ...     def load(self):
+    ...         self.features = range(10 ** 6)
+    ...         self.targets = range(10 ** 6)[::-1]
 
-            return lazy_property_getter, lazy_property_setter
+    """
+    def lazy_property_factory(lazy_property):
+        """Create properties that perform lazy loading of attributes."""
+        def lazy_property_getter(self):
+            if not hasattr(self, '_' + lazy_property):
+                self.load()
+            if not hasattr(self, '_' + lazy_property):
+                raise ValueError("{} wasn't loaded".format(lazy_property))
+            return getattr(self, '_' + lazy_property)
 
-        def wrap_dataset(dataset):
-            if not issubclass(dataset, InMemoryDataset):
-                raise ValueError("Only InMemoryDataset supports lazy loading")
+        def lazy_property_setter(self, value):
+            setattr(self, '_' + lazy_property, value)
 
-            # Attach the lazy loading properties to the class
-            for lazy_property in lazy_properties:
-                setattr(dataset, lazy_property,
-                        property(*lazy_property_factory(lazy_property)))
+        return lazy_property_getter, lazy_property_setter
 
-            # Delete the values of lazy properties when serializing
-            if not hasattr(dataset, '__getstate__'):
-                def __getstate__(self):
-                    serializable_state = self.__dict__.copy()
-                    for lazy_property in lazy_properties:
-                        attr = serializable_state.get('_' + lazy_property)
-                        # Iterators would lose their state
-                        if isinstance(attr, collections.Iterator):
-                            raise ValueError("Iterators can't be lazy loaded")
-                        serializable_state.pop('_' + lazy_property, None)
-                    return serializable_state
-                setattr(dataset, '__getstate__', __getstate__)
+    def wrap_class(cls):
+        # Attach the lazy loading properties to the class
+        for lazy_property in lazy_properties:
+            setattr(cls, lazy_property,
+                    property(*lazy_property_factory(lazy_property)))
 
-            return dataset
-        return wrap_dataset
+        # Delete the values of lazy properties when serializing
+        if not hasattr(cls, '__getstate__'):
+            def __getstate__(self):
+                serializable_state = self.__dict__.copy()
+                for lazy_property in lazy_properties:
+                    attr = serializable_state.get('_' + lazy_property)
+                    # Iterators would lose their state
+                    if isinstance(attr, collections.Iterator):
+                        raise ValueError("Iterators can't be lazy loaded")
+                    serializable_state.pop('_' + lazy_property, None)
+                return serializable_state
+            setattr(cls, '__getstate__', __getstate__)
+
+        return cls
+    return wrap_class

--- a/fuel/datasets/cifar10.py
+++ b/fuel/datasets/cifar10.py
@@ -3,14 +3,15 @@ import os
 
 import numpy
 import six
-from six.moves import  cPickle, xrange
+from six.moves import cPickle, xrange
 
 from fuel import config
 from fuel.datasets import InMemoryDataset
+from fuel.datasets.base import do_not_pickle_properties
 from fuel.schemes import SequentialScheme
 
 
-@InMemoryDataset.lazy_properties('features', 'targets')
+@do_not_pickle_properties('features', 'targets')
 class CIFAR10(InMemoryDataset):
     """The CIFAR10 dataset of natural images.
 

--- a/fuel/datasets/cifar10.py
+++ b/fuel/datasets/cifar10.py
@@ -7,11 +7,11 @@ from six.moves import cPickle, xrange
 
 from fuel import config
 from fuel.datasets import InMemoryDataset
-from fuel.datasets.base import do_not_pickle_properties
+from fuel.utils import do_not_pickle_attributes
 from fuel.schemes import SequentialScheme
 
 
-@do_not_pickle_properties('features', 'targets')
+@do_not_pickle_attributes('features', 'targets')
 class CIFAR10(InMemoryDataset):
     """The CIFAR10 dataset of natural images.
 

--- a/fuel/datasets/mnist.py
+++ b/fuel/datasets/mnist.py
@@ -6,12 +6,13 @@ import numpy
 
 from fuel import config
 from fuel.datasets import InMemoryDataset
+from fuel.datasets.base import do_not_pickle_properties
 from fuel.schemes import SequentialScheme
 MNIST_IMAGE_MAGIC = 2051
 MNIST_LABEL_MAGIC = 2049
 
 
-@InMemoryDataset.lazy_properties('features', 'targets')
+@do_not_pickle_properties('features', 'targets')
 class MNIST(InMemoryDataset):
     u"""The MNIST dataset of handwritten digits.
 

--- a/fuel/datasets/mnist.py
+++ b/fuel/datasets/mnist.py
@@ -6,13 +6,13 @@ import numpy
 
 from fuel import config
 from fuel.datasets import InMemoryDataset
-from fuel.datasets.base import do_not_pickle_properties
+from fuel.utils import do_not_pickle_attributes
 from fuel.schemes import SequentialScheme
 MNIST_IMAGE_MAGIC = 2051
 MNIST_LABEL_MAGIC = 2049
 
 
-@do_not_pickle_properties('features', 'targets')
+@do_not_pickle_attributes('features', 'targets')
 class MNIST(InMemoryDataset):
     u"""The MNIST dataset of handwritten digits.
 

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -64,6 +64,10 @@ def do_not_pickle_attributes(*lazy_properties):
             def __getstate__(self):
                 serializable_state = self.__dict__.copy()
                 for lazy_property in lazy_properties:
+                    attr = serializable_state.get('_' + lazy_property)
+                    # Iterators would lose their state
+                    if isinstance(attr, collections.Iterator):
+                        raise ValueError("Iterators can't be lazy loaded")
                     serializable_state.pop('_' + lazy_property, None)
                 return serializable_state
             setattr(cls, '__getstate__', __getstate__)

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -1,0 +1,76 @@
+import collections
+
+
+def do_not_pickle_attributes(*lazy_properties):
+    r"""Decorator to assign non-pickable properties.
+
+    Used to assign properties which will not be pickled on some class.
+    This decorator creates a series of properties whose values won't be
+    serialized; instead, their values will be reloaded (e.g. from disk) by
+    the :meth:`load` function after deserializing the object.
+
+    The decorator can be used with :class:`InMemoryDataset` to avoid
+    serialization of bulky attributes. Other possible way of using the
+    decorator is with attributes which cannot be pickled at all. In this
+    case the user should construct the attribute himself in :meth:`load`.
+
+    Parameters
+    ----------
+    \*lazy_properties : strings
+        The names of the attributes that are lazy.
+
+    Notes
+    -----
+    The pickling behavior of the dataset is only overridden if the
+    dataset does not have a ``__getstate__`` method implemented.
+
+    Examples
+    --------
+    In order to make sure that attributes are not serialized with the
+    dataset, and are lazily reloaded after deserialization by the
+    :meth:`load` in the wrapped class. Use the decorator with the names of
+    the attributes as an argument.
+
+    >>> from fuel.datasets import InMemoryDataset
+    >>> @do_not_pickle_attributes('features', 'targets')
+    ... class TestDataset(InMemoryDataset):
+    ...     def load(self):
+    ...         self.features = range(10 ** 6)
+    ...         self.targets = range(10 ** 6)[::-1]
+
+    """
+    def lazy_property_factory(lazy_property):
+        """Create properties that perform lazy loading of attributes."""
+        def lazy_property_getter(self):
+            if not hasattr(self, '_' + lazy_property):
+                self.load()
+            if not hasattr(self, '_' + lazy_property):
+                raise ValueError("{} wasn't loaded".format(lazy_property))
+            return getattr(self, '_' + lazy_property)
+
+        def lazy_property_setter(self, value):
+            setattr(self, '_' + lazy_property, value)
+
+        return lazy_property_getter, lazy_property_setter
+
+    def wrap_class(cls):
+        # Attach the lazy loading properties to the class
+        for lazy_property in lazy_properties:
+            setattr(cls, lazy_property,
+                    property(*lazy_property_factory(lazy_property)))
+
+        # Delete the values of lazy properties when serializing
+        if not hasattr(cls, '__getstate__'):
+            def __getstate__(self):
+                serializable_state = self.__dict__.copy()
+                for lazy_property in lazy_properties:
+                    attr = serializable_state.get('_' + lazy_property)
+                    # Iterators would lose their state
+                    if isinstance(attr, collections.Iterator):
+                        raise ValueError("Iterators can't be lazy loaded")
+                    serializable_state.pop('_' + lazy_property, None)
+                return serializable_state
+            setattr(cls, '__getstate__', __getstate__)
+
+        return cls
+    return wrap_class

--- a/fuel/utils.py
+++ b/fuel/utils.py
@@ -64,10 +64,6 @@ def do_not_pickle_attributes(*lazy_properties):
             def __getstate__(self):
                 serializable_state = self.__dict__.copy()
                 for lazy_property in lazy_properties:
-                    attr = serializable_state.get('_' + lazy_property)
-                    # Iterators would lose their state
-                    if isinstance(attr, collections.Iterator):
-                        raise ValueError("Iterators can't be lazy loaded")
                     serializable_state.pop('_' + lazy_property, None)
                 return serializable_state
             setattr(cls, '__getstate__', __getstate__)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import pickle
+from six.moves import range
+
+from fuel.utils import do_not_pickle_attributes
+
+
+@do_not_pickle_attributes("non_pickable", "bulky_attr")
+class TestClass(object):
+    def __init__(self):
+        self.load()
+
+    def load(self):
+        self.bulky_attr = list(range(100))
+        self.non_pickable = open(__file__, 'r')
+
+
+def test_do_not_pickle_attributes():
+    cl = TestClass()
+
+    dump = pickle.dumps(cl)
+
+    loaded = pickle.loads(dump)
+    assert loaded.bulky_attr == list(range(100))
+    assert loaded.non_pickable is not None
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 import pickle
 from six.moves import range
 
+from picklable_itertools import _iter
+
 from fuel.utils import do_not_pickle_attributes
 
 
@@ -11,7 +13,7 @@ class TestClass(object):
 
     def load(self):
         self.bulky_attr = list(range(100))
-        self.non_pickable = open(__file__, 'r')
+        self.non_pickable = lambda x: x
 
 
 def test_do_not_pickle_attributes():


### PR DESCRIPTION
Work is still in progress. Can you recommend a new name for `lazy_property_factory`? Or is it better to save this terminology?