### PR TITLE
WIP: Allow custom index range for IterationSchemes

### DIFF
--- a/fuel/schemes.py
+++ b/fuel/schemes.py
@@ -1,4 +1,5 @@
 from abc import ABCMeta, abstractmethod
+from collections import Iterable
 
 import numpy
 from picklable_itertools import chain, repeat, imap, iter_
@@ -58,9 +59,28 @@ class BatchScheme(IterationScheme):
     to be kept in memory, like MNIST) we can provide slices or lists of
     labels to the dataset.
 
+    Parameters
+    ----------
+    examples : int or list
+        Defines which examples from the dataset are iterated.
+        If list, its items are the indices of examples.
+        If an integer, it will use that many examples from the beginning
+        of the dataset, i.e. it is interpreted as range(examples)
+    batch_size : int
+        The request iterator will return slices or list of indices in
+        batches of size `batch_size` until the end of `examples` is
+        reached.
+        Note that this means that the last batch size returned could be
+        smaller than `batch_size`. If you want to ensure all batches are
+        of equal size, then ensure len(`examples`) or `examples` is a
+        multiple of `batch_size`.
+
     """
-    def __init__(self, num_examples, batch_size):
-        self.num_examples = num_examples
+    def __init__(self, examples, batch_size):
+        if isinstance(examples, Iterable):
+            self.indices = examples
+        else:
+            self.indices = xrange(examples)
         self.batch_size = batch_size
 
 
@@ -72,8 +92,11 @@ class IndexScheme(IterationScheme):
     but where we want to return single examples instead of batches.
 
     """
-    def __init__(self, num_examples):
-        self.num_examples = num_examples
+    def __init__(self, examples):
+        if isinstance(examples, Iterable):
+            self.indices = examples
+        else:
+            self.indices = xrange(examples)
 
 
 class ConstantScheme(BatchSizeScheme):
@@ -124,8 +147,7 @@ class SequentialScheme(BatchScheme):
 
     """
     def get_request_iterator(self):
-        return imap(list, partition_all(self.batch_size,
-                                        xrange(self.num_examples)))
+        return imap(list, partition_all(self.batch_size, self.indices))
 
 
 class ShuffledScheme(BatchScheme):
@@ -150,7 +172,7 @@ class ShuffledScheme(BatchScheme):
         super(ShuffledScheme, self).__init__(*args, **kwargs)
 
     def get_request_iterator(self):
-        indices = list(range(self.num_examples))
+        indices = list(self.indices)
         self.rng.shuffle(indices)
         return imap(list, partition_all(self.batch_size, indices))
 
@@ -162,7 +184,7 @@ class SequentialExampleScheme(IndexScheme):
 
     """
     def get_request_iterator(self):
-        return iter_(xrange(self.num_examples))
+        return iter_(self.indices)
 
 
 class ShuffledExampleScheme(IndexScheme):
@@ -178,6 +200,6 @@ class ShuffledExampleScheme(IndexScheme):
         super(ShuffledExampleScheme, self).__init__(*args, **kwargs)
 
     def get_request_iterator(self):
-        indices = list(range(self.num_examples))
+        indices = list(self.indices)
         self.rng.shuffle(indices)
         return iter_(indices)

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -29,6 +29,10 @@ def test_sequential_scheme():
     get_request_iterator = iterator_requester(SequentialScheme)
     assert list(get_request_iterator(5, 3)) == [[0, 1, 2], [3, 4]]
     assert list(get_request_iterator(4, 2)) == [[0, 1], [2, 3]]
+    assert list(get_request_iterator(
+        [4, 3, 2, 1, 0], 3)) == [[4, 3, 2], [1, 0]]
+    assert list(get_request_iterator(
+        [3, 2, 1, 0], 2)) == [[3, 2], [1, 0]]
 
 
 def test_shuffled_scheme():
@@ -41,6 +45,14 @@ def test_shuffled_scheme():
         [indices[:3], indices[3:6], indices[6:]]
     assert list(get_request_iterator(7, 3, rng=rng)) != \
         [indices[:3], indices[3:6], indices[6:]]
+
+    indices = list(range(6))[::-1]
+    expected = indices[:]
+    rng = numpy.random.RandomState(3)
+    test_rng = numpy.random.RandomState(3)
+    test_rng.shuffle(expected)
+    assert list(get_request_iterator(indices, 3, rng=rng)) == \
+        [expected[:3], expected[3:6]]
 
 
 def test_shuffled_example_scheme():
@@ -55,3 +67,4 @@ def test_shuffled_example_scheme():
 def test_sequential_example_scheme():
     get_request_iterator = iterator_requester(SequentialExampleScheme)
     assert list(get_request_iterator(7)) == list(range(7))
+    assert list(get_request_iterator(range(7)[::-1])) == list(range(7)[::-1])

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -15,7 +15,7 @@ def test_in_memory():
     # Load MNIST and get two batches
     mnist = MNIST('train')
     data_stream = DataStream(mnist, iteration_scheme=SequentialScheme(
-        num_examples=mnist.num_examples, batch_size=256))
+        examples=mnist.num_examples, batch_size=256))
     epoch = data_stream.get_epoch_iterator()
     for i, (features, targets) in enumerate(epoch):
         if i == 1:


### PR DESCRIPTION
A feature I need. If the iteration scheme is using only a subset of the indices from the datastream, I'd like to define the subset and not always assume I want to use the first ```num_examples```.

This requirement comes from the problem that if I artificially shrink my dataset with ```num_examples```, I might get a unbalanced number of different classes. Imagine someone giving ```num_examples=10```. It is unlikely, that all MNIST classes are represented there.

Another way to implement this would be to have a DataStreamWrapper that reorders indices or DataSet that reorders them, but this approach results in the smallest diff, I think.

Alternative implementation: ```num_examples``` parameter could also made to accept either an integer or an iterable in which case it would be renamed to, say, ```examples``` and code would like:

```self.indices = xrange(examples) if type(examples) is int else examples```