### PR TITLE
The big rename (Transformers). Fixes #23.

### DIFF
--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -218,7 +218,7 @@ class IterableDataset(Dataset):
     decorator.
 
     To iterate over a container in batches, combine this dataset with the
-    :class:`BatchDataStream` data stream.
+    :class:`Batch` data stream.
 
     """
     example_iteration_scheme = None

--- a/fuel/iterator.py
+++ b/fuel/iterator.py
@@ -6,7 +6,7 @@ class DataIterator(six.Iterator):
 
     Parameters
     ----------
-    data_stream : :class:`DataStream` or :class:`DataStreamWrapper`
+    data_stream : :class:`DataStream` or :class:`Transformer`
         The data stream over which to iterate.
     request_iterator : iterator
         An iterator which returns the request to pass to the data stream

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -1,0 +1,137 @@
+from abc import ABCMeta, abstractmethod
+
+from six import add_metaclass
+
+from fuel.iterator import DataIterator
+
+
+@add_metaclass(ABCMeta)
+class AbstractDataStream(object):
+    """A stream of data separated into epochs.
+
+    A data stream is an iterable stream of examples/minibatches. It shares
+    similarities with Python file handles return by the ``open`` method.
+    Data streams can be closed using the :meth:`close` method and reset
+    using :meth:`reset` (similar to ``f.seek(0)``).
+
+    Parameters
+    ----------
+    iteration_scheme : :class:`.IterationScheme`, optional
+        The iteration scheme to use when retrieving data. Note that not all
+        datasets support the same iteration schemes, some datasets require
+        one, and others don't support any. In case when the data stream
+        wraps another data stream, the choice of supported iteration
+        schemes is typically even more limited. Be sure to read the
+        documentation of the dataset or data stream in question.
+
+    Attributes
+    ----------
+    iteration_scheme : :class:`.IterationScheme`
+        The iteration scheme used to retrieve data. Can be ``None`` when
+        not used.
+    sources : tuple of strings
+        The names of the data sources returned by this data stream, as
+        given by the dataset.
+
+    """
+    def __init__(self, iteration_scheme=None):
+        self.iteration_scheme = iteration_scheme
+
+    def get_data(self, request=None):
+        """Request data from the dataset or the wrapped stream.
+
+        Parameters
+        ----------
+        request : object
+            A request fetched from the `request_iterator`.
+
+        """
+        pass
+
+    @abstractmethod
+    def reset(self):
+        """Reset the data stream."""
+        pass
+
+    @abstractmethod
+    def close(self):
+        """Gracefully close the data stream, e.g. releasing file handles."""
+        pass
+
+    @abstractmethod
+    def next_epoch(self):
+        """Switch the data stream to the next epoch."""
+        pass
+
+    @abstractmethod
+    def get_epoch_iterator(self, as_dict=False):
+        return DataIterator(self, self.iteration_scheme.get_request_iterator()
+                            if self.iteration_scheme else None,
+                            as_dict=as_dict)
+
+    def iterate_epochs(self, as_dict=False):
+        """Allow iteration through all epochs.
+
+        Notes
+        -----
+        This method uses the :meth:`get_epoch_iterator` method to retrieve
+        the :class:`DataIterator` for each epoch. The default
+        implementation of this method resets the state of the data stream
+        so that the new epoch can read the data from the beginning.
+        However, this behavior only works as long as the ``epochs``
+        property is iterated over using e.g. ``for epoch in
+        stream.epochs``. If you create the data iterators in advance (e.g.
+        using ``for i, epoch in zip(range(10), stream.epochs`` in Python 2)
+        you must call the :meth:`reset` method yourself.
+
+        """
+        while True:
+            yield self.get_epoch_iterator(as_dict=as_dict)
+
+
+class DataStream(AbstractDataStream):
+    """A stream of data from a dataset.
+
+    Parameters
+    ----------
+    dataset : instance of :class:`Dataset`
+        The dataset from which the data is fetched.
+
+    """
+    def __init__(self, dataset, **kwargs):
+        super(DataStream, self).__init__(**kwargs)
+        self.dataset = dataset
+        self.data_state = self.dataset.open()
+        self._fresh_state = True
+
+    @property
+    def sources(self):
+        if hasattr(self, '_sources'):
+            return self._sources
+        return self.dataset.sources
+
+    @sources.setter
+    def sources(self, value):
+        self._sources = value
+
+    def close(self):
+        self.data_state = self.dataset.close(self.data_state)
+
+    def reset(self):
+        self.data_state = self.dataset.reset(self.data_state)
+        self._fresh_state = True
+
+    def next_epoch(self):
+        self.data_state = self.dataset.next_epoch(self.data_state)
+
+    def get_data(self, request=None):
+        """Get data from the dataset."""
+        return self.dataset.get_data(self.data_state, request)
+
+    def get_epoch_iterator(self, **kwargs):
+        """Get an epoch iterator for the data stream."""
+        if not self._fresh_state:
+            self.next_epoch()
+        else:
+            self._fresh_state = False
+        return super(DataStream, self).get_epoch_iterator(**kwargs)

--- a/fuel/transformers/text.py
+++ b/fuel/transformers/text.py
@@ -1,7 +1,7 @@
-from fuel.streams import DataStreamWrapper
+from fuel.transformers import Transformer
 
 
-class NGramStream(DataStreamWrapper):
+class NGrams(Transformer):
     """Return n-grams from a stream.
 
     This data stream wrapper takes as an input a data stream outputting
@@ -27,7 +27,7 @@ class NGramStream(DataStreamWrapper):
     def __init__(self, ngram_order, data_stream, target_source='targets'):
         if len(data_stream.sources) > 1:
             raise ValueError
-        super(NGramStream, self).__init__(data_stream)
+        super(NGrams, self).__init__(data_stream)
         self.sources = self.sources + (target_source,)
         self.ngram_order = ngram_order
         self.sentence = []

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -7,7 +7,7 @@ from six.moves import cPickle
 
 from fuel.datasets import TextFile, IterableDataset
 from fuel.streams import DataStream
-from fuel.streams.text import NGramStream
+from fuel.transformers.text import NGrams
 
 
 def lower(s):
@@ -58,5 +58,5 @@ def test_ngram_stream():
     sentences = [list(numpy.random.randint(10, size=sentence_length))
                  for sentence_length in [3, 5, 7]]
     stream = IterableDataset(sentences).get_example_stream()
-    ngrams = NGramStream(4, stream)
+    ngrams = NGrams(4, stream)
     assert len(list(ngrams.get_epoch_iterator())) == 4


### PR DESCRIPTION
This renames `DataStreamWrapper`s to `Transformer` as discussed in #23.

This also means that a lot of the names we had (`MappingStream`, `PaddingStream`, etc.) seemed wrong now. After some pondering, I figured that maybe it was just best to remove all those redundant suffixes. From the module they are in, it's clear that they are wrappers/streams/transformers, so just `Mapping`, `Padding`, etc. should do just fine IMHO.