### PR TITLE
Speed up TextFile dataset and Merge transformer

### DIFF
--- a/fuel/datasets/text.py
+++ b/fuel/datasets/text.py
@@ -95,10 +95,13 @@ class TextFile(Dataset):
             sentence = self.preprocess(sentence)
         data = [self.dictionary[self.bos_token]] if self.bos_token else []
         if self.level == 'word':
-            data += [self.dictionary.get(word, self.dictionary[self.unk_token])
-                     for word in sentence.split()]
+            data.extend(self.dictionary.get(word,
+                                            self.dictionary[self.unk_token])
+                        for word in sentence.split())
         else:
-            data += [self.dictionary.get(char, self.dictionary[self.unk_token])
-                     for char in sentence.strip()]
-        data += [self.dictionary[self.eos_token]] if self.eos_token else []
+            data.extend(self.dictionary.get(char,
+                                            self.dictionary[self.unk_token])
+                        for char in sentence.strip())
+        if self.eos_token:
+            data.append(self.dictionary[self.eos_token])
         return (data,)

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -367,6 +367,7 @@ class Merge(Transformer):
         self.sources = sources
 
     def get_epoch_iterator(self, **kwargs):
-        batches = chain(*izip(*[data_stream.get_epoch_iterator()
-                                for data_stream in self.data_streams]))
-        return partition(len(self.sources), chain(*batches))
+        batches = chain.from_iterable(
+            izip(*[data_stream.get_epoch_iterator()
+                   for data_stream in self.data_streams]))
+        return partition(len(self.sources), chain.from_iterable(batches))


### PR DESCRIPTION
Oops, the `Merge` transformer was converting the streams to lists in memory, making it unworkable for large streams. This should fix that, and also speeds up the `TextFile` dataset a little bit by extending lists instead of creating new, concatenated ones.