### PR TITLE
Add multiprocessing stream from @lukemetz

### DIFF
--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,10 @@
+from fuel.datasets import IterableDataset
+from fuel.transformers import Mapping, MultiProcessing
+
+
+def test_multiprocessing():
+    stream = IterableDataset(range(100)).get_example_stream()
+    plus_one = Mapping(stream, lambda x: (x[0] + 1,))
+    background = MultiProcessing(plus_one)
+    for a, b in zip(background.get_epoch_iterator(), range(1, 101)):
+        assert a == (b,)


### PR DESCRIPTION
Haven't benchmarked it, but it seems to work and @lukemetz has reported speedups, so we might as well put it in here to address #7 for the cases where we don't need a super-optimized solution.

I took @lukemetz's original code and added some documentation. Instead of relying on `__del__` to exit the process I turned it into a daemon, which means it will just get killed as soon as the main process stops. I'm not 100% sure if this could cause problems in case file handles are left open or something, but I think it's safer than relying on `__del__`.