### PR TITLE
Fixing concatenation of list to tuple bug

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -104,8 +104,8 @@ class Mapping(Transformer):
 
     @property
     def sources(self):
-        return self.data_stream.sources + (self.add_sources
-                                           if self.add_sources else ())
+        return self.data_stream.sources + [self.add_sources
+                                           if self.add_sources else ()]
 
     def get_data(self, request=None):
         if request is not None:


### PR DESCRIPTION
self.data_stream.sources is a list, but it was being concatenated to a tuple. I converted the list comprehension to a list so it will not fail.