### PR TITLE
Add download script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ cache:
   directories:
     - $TRAVIS_BUILD_DIR/mnist
     - $TRAVIS_BUILD_DIR/cifar10
-    - $TRAVIS_BUILD_DIR/binarized_mnist
 branches:
   only:
     - master
@@ -56,10 +55,12 @@ install:
 script:
   - pip install . -r requirements.txt
   - |
-      if [ ! -f binarized_mnist/binarized_mnist.hdf5 ]; then
-        fuel-convert binarized_mnist \
-                     -d binarized_mnist \
-                     -o binarized_mnist/binarized_mnist.hdf5
+      if [ ! -f binarized_mnist_train.amat ]; then
+        fuel-download binarized_mnist
+      fi
+  - |
+      if [ ! -f binarized_mnist.hdf5 ]; then
+        fuel-convert binarized_mnist
       fi
   # With Fuel installed we can install Blocks
   - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,10 @@ install:
 script:
   - pip install . -r requirements.txt
   - |
-      if [ ! -f binarized_mnist_train.amat ]; then
-        fuel-download binarized_mnist
-      fi
-  - |
       if [ ! -f binarized_mnist.hdf5 ]; then
+        fuel-download binarized_mnist
         fuel-convert binarized_mnist
+        rm binarized_mnist_{train,valid,test}.amat
       fi
   # With Fuel installed we can install Blocks
   - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
       if [ ! -f binarized_mnist.hdf5 ]; then
         fuel-download binarized_mnist
         fuel-convert binarized_mnist
-        fuel-download --clear binarized_mnist
+        fuel-download binarized_mnist --clear
       fi
   # With Fuel installed we can install Blocks
   - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
       if [ ! -f binarized_mnist.hdf5 ]; then
         fuel-download binarized_mnist
         fuel-convert binarized_mnist
-        rm binarized_mnist_{train,valid,test}.amat
+        fuel-download --clear binarized_mnist
       fi
   # With Fuel installed we can install Blocks
   - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,6 @@ before_install:
         gunzip *-ubyte.gz
         cd -
       fi
-  # Download binarized MNIST for tests if not loaded from cache
-  - |
-      if find binarized_mnist -empty | read; then
-        mkdir binarized_mnist
-        cd binarized_mnist
-        curl -O http://www.cs.toronto.edu/~larocheh/public/datasets/binarized_mnist/binarized_mnist_train.amat \
-             -O http://www.cs.toronto.edu/~larocheh/public/datasets/binarized_mnist/binarized_mnist_valid.amat \
-             -O http://www.cs.toronto.edu/~larocheh/public/datasets/binarized_mnist/binarized_mnist_test.amat
-        cd -
-      fi
     # Download CIFAR10 for tests if not loaded from cache
   - |
       if find cifar10 -empty | read; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 cache:
   directories:
-    - $TRAVIS_BUILD_DIR/mnist
-    - $TRAVIS_BUILD_DIR/cifar10
+    - $TRAVIS_BUILD_DIR/data
 branches:
   only:
     - master
@@ -19,9 +18,9 @@ before_install:
   - conda update -q --yes conda
   # Download MNIST for tests if not loaded from cache
   - |
-      if find mnist -empty | read; then
-        mkdir mnist
-        cd mnist
+      if find $TRAVIS_BUILD_DIR/data/mnist -empty | read; then
+        mkdir $TRAVIS_BUILD_DIR/data/mnist
+        cd $TRAVIS_BUILD_DIR/data/mnist
         curl -O http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz \
              -O http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz \
              -O http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz \
@@ -31,24 +30,27 @@ before_install:
       fi
     # Download CIFAR10 for tests if not loaded from cache
   - |
-      if find cifar10 -empty | read; then
-        mkdir cifar10
-        cd cifar10
+      if find $TRAVIS_BUILD_DIR/data/cifar10 -empty | read; then
+        mkdir $TRAVIS_BUILD_DIR/data/cifar10
+        cd $TRAVIS_BUILD_DIR/data/cifar10
         curl http://www.cs.utoronto.ca/~kriz/cifar-10-python.tar.gz | tar xzf -
         cd -
       fi
-  - export FUEL_DATA_PATH=$PWD
+  - export FUEL_DATA_PATH=$TRAVIS_BUILD_DIR/data
 install:
   # Install all Python dependencies
   - conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl bokeh nose numpy pip coverage six toolz pytables h5py
   - pip install -q coveralls
 script:
   - pip install . -r requirements.txt
+  # Download and process binarized MNIST for tests if not loaded from cache
   - |
-      if [ ! -f binarized_mnist.hdf5 ]; then
+      if [ ! -f $FUEL_DATA_PATH/binarized_mnist.hdf5 ]; then
+        cd $FUEL_DATA_PATH
         fuel-download binarized_mnist
         fuel-convert binarized_mnist
-        fuel-download binarized_mnist --clear
+        fuel-download --clear binarized_mnist
+        cd -
       fi
   # With Fuel installed we can install Blocks
   - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ before_install:
   - conda update -q --yes conda
   # Download MNIST for tests if not loaded from cache
   - |
-      if find $TRAVIS_BUILD_DIR/data/mnist -empty | read; then
+      if [ ! -d $TRAVIS_BUILD_DIR/data/mnist ]; then
         mkdir $TRAVIS_BUILD_DIR/data/mnist
+      fi
+  - |
+      if find $TRAVIS_BUILD_DIR/data/mnist -empty | read; then
         cd $TRAVIS_BUILD_DIR/data/mnist
         curl -O http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz \
              -O http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz \
@@ -30,8 +33,11 @@ before_install:
       fi
     # Download CIFAR10 for tests if not loaded from cache
   - |
-      if find $TRAVIS_BUILD_DIR/data/cifar10 -empty | read; then
+      if [ ! -d $TRAVIS_BUILD_DIR/data/cifar10 ]; then
         mkdir $TRAVIS_BUILD_DIR/data/cifar10
+      fi
+  - |
+      if find $TRAVIS_BUILD_DIR/data/cifar10 -empty | read; then
         cd $TRAVIS_BUILD_DIR/data/cifar10
         curl http://www.cs.utoronto.ca/~kriz/cifar-10-python.tar.gz | tar xzf -
         cd -

--- a/bin/fuel-convert
+++ b/bin/fuel-convert
@@ -13,9 +13,12 @@ if __name__ == "__main__":
                         choices=dataset_options.keys())
     parser.add_argument("-d", "--directory", help="directory in which input " +
                         "files reside", type=str, default=os.getcwd())
-    parser.add_argument("-o", "--output-directory", help="where to save the " +
-                        "dataset", type=str, default=os.getcwd())
+    parser.add_argument("-o", "--output-file", help="where to save the " +
+                        "dataset", type=str, default=None)
     args = parser.parse_args()
 
+    output_file = args.output_file
+    if output_file is None:
+        output_file = os.path.join(os.getcwd(), '{}.hdf5'.format(args.dataset))
     dataset_options[args.dataset](
-        input_directory=args.directory, save_directory=args.output_directory)
+        input_directory=args.directory, save_path=output_file)

--- a/bin/fuel-convert
+++ b/bin/fuel-convert
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 import argparse
-import importlib
-import pkgutil
 
 from fuel import converters
 

--- a/bin/fuel-convert
+++ b/bin/fuel-convert
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import os
 
 from fuel import converters
 
@@ -11,10 +12,10 @@ if __name__ == "__main__":
     parser.add_argument("dataset", help="what dataset to convert",
                         choices=dataset_options.keys())
     parser.add_argument("-d", "--directory", help="directory in which input " +
-                        "files reside", type=str, default=None)
-    parser.add_argument("-o", "--output-file", help="where to save the " +
-                        "dataset", type=str, default=None)
+                        "files reside", type=str, default=os.getcwd())
+    parser.add_argument("-o", "--output-directory", help="where to save the " +
+                        "dataset", type=str, default=os.getcwd())
     args = parser.parse_args()
 
     dataset_options[args.dataset](
-        directory=args.directory, save_path=args.output_file)
+        input_directory=args.directory, save_directory=args.output_directory)

--- a/bin/fuel-download
+++ b/bin/fuel-download
@@ -6,15 +6,13 @@ from fuel import downloaders
 
 
 if __name__ == "__main__":
-    dataset_options = dict(
+    built_in_datasets = dict(
         (name, getattr(downloaders, name)) for name in downloaders.__all__)
-    parser = argparse.ArgumentParser()
-    parser.add_argument("dataset", help="what dataset to download",
-                        choices=dataset_options.keys())
-    parser.add_argument("-d", "--directory", help="where to save the " +
-                        "downloaded files", type=str, default=os.getcwd())
-    parser.add_argument("--clear", help="clear the downloaded files",
-                        action='store_true')
+    parser = argparse.ArgumentParser(
+        description='Download script for built-in datasets.')
+    subparsers = parser.add_subparsers()
+    for name, subparser_fn in built_in_datasets.items():
+        subparser_fn(subparsers.add_parser(
+            name, help='Download the {} dataset'.format(name)))
     args = parser.parse_args()
-    dataset_options[args.dataset](
-        save_directory=args.directory, clear=args.clear)
+    args.func(args)

--- a/bin/fuel-download
+++ b/bin/fuel-download
@@ -10,6 +10,10 @@ if __name__ == "__main__":
         (name, getattr(downloaders, name)) for name in downloaders.__all__)
     parser = argparse.ArgumentParser(
         description='Download script for built-in datasets.')
+    parser.add_argument("-d", "--directory", help="where to save the " +
+                        "downloaded files", type=str, default=os.getcwd())
+    parser.add_argument("--clear", help="clear the downloaded files",
+                        action='store_true')
     subparsers = parser.add_subparsers()
     for name, subparser_fn in built_in_datasets.items():
         subparser_fn(subparsers.add_parser(

--- a/bin/fuel-download
+++ b/bin/fuel-download
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import os
 
 from fuel import downloaders
 
@@ -11,6 +12,6 @@ if __name__ == "__main__":
     parser.add_argument("dataset", help="what dataset to download",
                         choices=dataset_options.keys())
     parser.add_argument("-d", "--directory", help="where to save the " +
-                        "downloaded files", type=str, default=None)
+                        "downloaded files", type=str, default=os.getcwd())
     args = parser.parse_args()
-    dataset_options[args.dataset](save_path=args.directory)
+    dataset_options[args.dataset](save_directory=args.directory)

--- a/bin/fuel-download
+++ b/bin/fuel-download
@@ -13,5 +13,8 @@ if __name__ == "__main__":
                         choices=dataset_options.keys())
     parser.add_argument("-d", "--directory", help="where to save the " +
                         "downloaded files", type=str, default=os.getcwd())
+    parser.add_argument("--clear", help="clear the downloaded files",
+                        action='store_true')
     args = parser.parse_args()
-    dataset_options[args.dataset](save_directory=args.directory)
+    dataset_options[args.dataset](
+        save_directory=args.directory, clear=args.clear)

--- a/bin/fuel-download
+++ b/bin/fuel-download
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import argparse
+
+from fuel import downloaders
+
+
+if __name__ == "__main__":
+    dataset_options = dict(
+        (name, getattr(downloaders, name)) for name in downloaders.__all__)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dataset", help="what dataset to download",
+                        choices=dataset_options.keys())
+    parser.add_argument("-d", "--directory", help="where to save the " +
+                        "downloaded files", type=str, default=None)
+    args = parser.parse_args()
+    dataset_options[args.dataset](save_path=args.directory)

--- a/fuel/converters/__init__.py
+++ b/fuel/converters/__init__.py
@@ -3,16 +3,11 @@
 Conversion submodules generate an HDF5 file that is compatible with
 their corresponding built-in dataset.
 
-Conversion methods accept two arguments:
+Conversion functions accept two arguments:
 
-* `directory` : The directory containing input files expected by the
-                conversion method. If not specified, `convert` should
-                use the directory in which the corresponding built-in
-                dataset expects to find the data.
-* `save_path` : Where to save the converted data. If not specified,
-                `convert` should provide a sensible default name and
-                put the file in the directory in which the corresponding
-                built-in dataset expects to find the data.
+* `input_directory` : Directory containing input files expected by the
+                      conversion function.
+* `save_directory`  : Directory in which the converted data is saved.
 
 """
 from fuel.converters.binarized_mnist import binarized_mnist

--- a/fuel/converters/__init__.py
+++ b/fuel/converters/__init__.py
@@ -7,7 +7,7 @@ Conversion functions accept two arguments:
 
 * `input_directory` : Directory containing input files expected by the
                       conversion function.
-* `save_directory`  : Directory in which the converted data is saved.
+* `save_path`  : Where to save the converted dataset.
 
 """
 from fuel.converters.binarized_mnist import binarized_mnist

--- a/fuel/converters/base.py
+++ b/fuel/converters/base.py
@@ -1,0 +1,30 @@
+import numpy
+
+
+def fill_hdf5_file(h5file, data, source_names, shapes, dtypes,
+                   split_names, splits):
+    """Fills an HDF5 file in a H5PYDataset-compatible manner.
+
+    Parameters
+    ----------
+    h5file : :class:`h5py.File`
+        File handle for an HDF5 file.
+    data : list of lists of :class:`numpy.ndarray`
+        Rows correspond to sources, columns correspond to splits.
+    source_names : tuple of str
+        Source names of the corresponding rows in `data`.
+    shapes : tuple of tuples of int
+        Shape of the concatenated splits of the corresponding rows in `data`.
+    dtypes : tuple of str
+        Data types of the corresponding rows in `data`.
+    split_names : tuple of str
+        Split names of the corresponding columns in `data`.
+    splits : tuple of :class:`numpy.ndarray`
+        Split start and stop indices of the corresponding columns in `data`.
+
+    """
+    for name, split in zip(split_names, splits):
+        h5file.attrs[name] = split
+    for source, name, shape, dtype in zip(data, source_names, shapes, dtypes):
+        dataset = h5file.create_dataset(name, shape, dtype=dtype)
+        dataset[...] = numpy.vstack(source)

--- a/fuel/converters/base.py
+++ b/fuel/converters/base.py
@@ -14,13 +14,15 @@ def fill_hdf5_file(h5file, data, source_names, shapes, dtypes,
     source_names : tuple of str
         Source names of the corresponding rows in `data`.
     shapes : tuple of tuples of int
-        Shape of the concatenated splits of the corresponding rows in `data`.
+        Shape of the concatenated splits of the corresponding rows in
+        `data`.
     dtypes : tuple of str
         Data types of the corresponding rows in `data`.
     split_names : tuple of str
         Split names of the corresponding columns in `data`.
     splits : tuple of :class:`numpy.ndarray`
-        Split start and stop indices of the corresponding columns in `data`.
+        Split start and stop indices of the corresponding columns in
+        `data`.
 
     """
     for name, split in zip(split_names, splits):

--- a/fuel/converters/binarized_mnist.py
+++ b/fuel/converters/binarized_mnist.py
@@ -4,16 +4,14 @@ import fuel
 import h5py
 import numpy
 
-default_directory = os.path.join(fuel.config.data_path, 'binarized_mnist')
-default_save_path = os.path.join(default_directory, 'binarized_mnist.hdf5')
 
-
-def binarized_mnist(directory=None, save_path=None):
+def binarized_mnist(input_directory, save_directory):
     """Converts the binarized MNIST dataset to HDF5.
 
     Converts the binarized MNIST dataset used in R. Salakhutdinov's DBN
     paper [DBN] to an HDF5 dataset compatible with
-    :class:`fuel.datasets.BinarizedMNIST`.
+    :class:`fuel.datasets.BinarizedMNIST`. The converted dataset is
+    saved as 'binarized_mnist.hdf5'.
 
     This method assumes the existence of the files
     `binarized_mnist_{train,valid,test}.amat`, which are accessible
@@ -28,27 +26,21 @@ def binarized_mnist(directory=None, save_path=None):
 
     Parameters
     ----------
-    directory : str, optional
-        Base directory in which the required input files reside. Defaults
-        to `None`, in which case `'$FUEL_DATA_PATH/binarized_mnist'` is
-        used.
-    save_path : str, optional
-        Where to save the converted dataset. Defaults to `None`, in which
-        case `'$FUEL_DATA_PATH/binarized_mnist/binarized_mnist.hdf5'` is
-        used.
+    input_directory : str
+        Directory in which the required input files reside.
+    save_directory : str
+        Directory in which the the converted dataset is saved.
 
     """
-    if directory is None:
-        directory = default_directory
-    if save_path is None:
-        save_path = default_save_path
+    file_name = 'binarized_mnist.hdf5'
+    save_path = os.path.join(save_directory, file_name)
 
     train_set = numpy.loadtxt(
-        os.path.join(directory, 'binarized_mnist_train.amat'))
+        os.path.join(input_directory, 'binarized_mnist_train.amat'))
     valid_set = numpy.loadtxt(
-        os.path.join(directory, 'binarized_mnist_valid.amat'))
+        os.path.join(input_directory, 'binarized_mnist_valid.amat'))
     test_set = numpy.loadtxt(
-        os.path.join(directory, 'binarized_mnist_test.amat'))
+        os.path.join(input_directory, 'binarized_mnist_test.amat'))
 
     f = h5py.File(save_path, mode="w")
 

--- a/fuel/converters/binarized_mnist.py
+++ b/fuel/converters/binarized_mnist.py
@@ -1,6 +1,5 @@
 import os
 
-import fuel
 import h5py
 import numpy
 

--- a/fuel/converters/binarized_mnist.py
+++ b/fuel/converters/binarized_mnist.py
@@ -4,7 +4,7 @@ import h5py
 import numpy
 
 
-def binarized_mnist(input_directory, save_directory):
+def binarized_mnist(input_directory, save_path):
     """Converts the binarized MNIST dataset to HDF5.
 
     Converts the binarized MNIST dataset used in R. Salakhutdinov's DBN
@@ -27,13 +27,10 @@ def binarized_mnist(input_directory, save_directory):
     ----------
     input_directory : str
         Directory in which the required input files reside.
-    save_directory : str
-        Directory in which the the converted dataset is saved.
+    save_path : str
+        Where to save the converted dataset.
 
     """
-    file_name = 'binarized_mnist.hdf5'
-    save_path = os.path.join(save_directory, file_name)
-
     train_set = numpy.loadtxt(
         os.path.join(input_directory, 'binarized_mnist_train.amat'))
     valid_set = numpy.loadtxt(

--- a/fuel/datasets/binarized_mnist.py
+++ b/fuel/datasets/binarized_mnist.py
@@ -42,7 +42,6 @@ class BinarizedMNIST(H5PYDataset):
         set (10,000 samples) or the test set (10,000 samples).
 
     """
-    folder = 'binarized_mnist'
     filename = 'binarized_mnist.hdf5'
 
     def __init__(self, which_set, load_in_memory=True, **kwargs):
@@ -55,4 +54,4 @@ class BinarizedMNIST(H5PYDataset):
 
     @property
     def data_path(self):
-        return os.path.join(config.data_path, self.folder, self.filename)
+        return os.path.join(config.data_path, self.filename)

--- a/fuel/datasets/binarized_mnist.py
+++ b/fuel/datasets/binarized_mnist.py
@@ -44,8 +44,8 @@ class BinarizedMNIST(H5PYDataset):
     """
     filename = 'binarized_mnist.hdf5'
 
-    def __init__(self, which_set, load_in_memory=True, **kwargs):
-        if which_set not in ('train', 'valid', 'test'):
+    def __init__(self, which_set=None, load_in_memory=True, **kwargs):
+        if which_set and which_set not in ('train', 'valid', 'test'):
             raise ValueError("available splits are 'train', 'valid' and "
                              "'test'")
         super(BinarizedMNIST, self).__init__(

--- a/fuel/downloaders/__init__.py
+++ b/fuel/downloaders/__init__.py
@@ -1,7 +1,9 @@
 """Download modules for built-in datasets.
 
-Download methods accept a single argument, `save_directory`, which tells
-where to save the downloaded files.
+Download methods accept two arguments:
+
+* `save_directory` : Where to save the downloaded files
+* `clear` : If `True`, clear the downloaded files. Defaults to `False`.
 
 """
 from fuel.downloaders.binarized_mnist import binarized_mnist

--- a/fuel/downloaders/__init__.py
+++ b/fuel/downloaders/__init__.py
@@ -1,0 +1,9 @@
+"""Download modules for built-in datasets.
+
+Download methods accept a single argument, `save_path`, which tells
+where to save the downloaded files.
+
+"""
+from fuel.downloaders.binarized_mnist import binarized_mnist
+
+__all__ = ('binarized_mnist',)

--- a/fuel/downloaders/__init__.py
+++ b/fuel/downloaders/__init__.py
@@ -1,6 +1,6 @@
 """Download modules for built-in datasets.
 
-Download methods accept a single argument, `save_path`, which tells
+Download methods accept a single argument, `save_directory`, which tells
 where to save the downloaded files.
 
 """

--- a/fuel/downloaders/base.py
+++ b/fuel/downloaders/base.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+
+import urllib3
+from urllib3.util.url import parse_url
+
+
+def download(url, path=None):
+    """Downloads a given URL to a specific directory or file.
+
+    Parameters
+    ----------
+    url : str
+        URL to download.
+    path : str, optional
+        Where to save the downloaded URL. Defaults to `None`, in which
+        case the current working directory is used.
+
+    """
+    http = urllib3.PoolManager()
+    with http.request('GET', url, preload_content=False) as response:
+        if not path:
+            path = os.getcwd()
+        if os.path.isdir(path):
+            headers = response.getheaders()
+            if 'Content-Disposition' in headers:
+                filename = headers[
+                    'Content-Disposition'].split('filename=')[1].trim('"')
+            else:
+                filename = os.path.basename(parse_url(url).path)
+            if not filename:
+                raise ValueError("no filename given")
+            path = os.path.join(path, filename)
+        with open(path, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)

--- a/fuel/downloaders/base.py
+++ b/fuel/downloaders/base.py
@@ -33,3 +33,27 @@ def download(url, path=None):
             path = os.path.join(path, filename)
         with open(path, 'wb') as out_file:
             shutil.copyfileobj(response, out_file)
+
+
+def default_manager(urls, filenames):
+    """Returns a function to download or clear files from a list of URLs.
+
+    Parameters
+    ----------
+    urls : list of str
+        URLs to download from.
+    filenames : list of str
+        Files to save to.
+
+    """
+    def manager_fn(args):
+        save_directory = args.directory
+        files = [os.path.join(save_directory, f) for f in filenames]
+        if args.clear:
+            for f in files:
+                if os.path.isfile(f):
+                    os.remove(f)
+        else:
+            for url, f in zip(urls, files):
+                download(url, f)
+    return manager_fn

--- a/fuel/downloaders/base.py
+++ b/fuel/downloaders/base.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+import certifi
 import urllib3
 from urllib3.util.url import parse_url
 
@@ -17,7 +18,8 @@ def download(url, path=None):
         case the current working directory is used.
 
     """
-    http = urllib3.PoolManager()
+    http = urllib3.PoolManager(
+        cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
     with http.request('GET', url, preload_content=False) as response:
         if not path:
             path = os.getcwd()

--- a/fuel/downloaders/base.py
+++ b/fuel/downloaders/base.py
@@ -37,25 +37,30 @@ def download(url, path=None):
             shutil.copyfileobj(response, out_file)
 
 
-def default_manager(urls, filenames):
-    """Returns a function to download or clear files from a list of URLs.
+def default_downloader(args):
+    """Downloads or clears files from URLs and filenames.
+
+    This function takes an :class:`argparse.Namespace` instance as
+    argument and expects it to contain three attributes:
+
+    * `directory` : directory in which downloaded files are saved
+    * `urls` : list of URLs to download
+    * `filenames` : list of file names for the corresponding URLs
 
     Parameters
     ----------
-    urls : list of str
-        URLs to download from.
-    filenames : list of str
-        Files to save to.
+    args : :class:`argparse.Namespace`
+        Parsed command line arguments
 
     """
-    def manager_fn(args):
-        save_directory = args.directory
-        files = [os.path.join(save_directory, f) for f in filenames]
-        if args.clear:
-            for f in files:
-                if os.path.isfile(f):
-                    os.remove(f)
-        else:
-            for url, f in zip(urls, files):
-                download(url, f)
-    return manager_fn
+    urls = args.urls
+    save_directory = args.directory
+    filenames = args.filenames
+    files = [os.path.join(save_directory, f) for f in filenames]
+    if args.clear:
+        for f in files:
+            if os.path.isfile(f):
+                os.remove(f)
+    else:
+        for url, f in zip(urls, files):
+            download(url, f)

--- a/fuel/downloaders/base.py
+++ b/fuel/downloaders/base.py
@@ -80,5 +80,5 @@ def default_downloader(args):
                 os.remove(f)
     else:
         for url, f in zip(urls, files):
-            with open(f, 'w') as file_handle:
+            with open(f, 'wb') as file_handle:
                 download(url, file_handle)

--- a/fuel/downloaders/binarized_mnist.py
+++ b/fuel/downloaders/binarized_mnist.py
@@ -1,0 +1,35 @@
+import os
+from subprocess import call
+
+import fuel
+
+default_save_path = os.path.join(fuel.config.data_path, 'binarized_mnist')
+
+
+def binarized_mnist(save_path=None):
+    """Downloads the binarized MNIST dataset files.
+
+    The binarized MNIST dataset files
+    (`binarized_mnist_{train,valid,test}.amat`) are downloaded from
+    Hugo Larochelle's website [HUGO].
+
+    .. [HUGO] http://www.cs.toronto.edu/~larocheh/public/datasets/
+       binarized_mnist/binarized_mnist_{train,valid,test}.amat
+
+    Parameters
+    ----------
+    save_path : str, optional
+        Where to save the downloaded files. Defaults to `None`, in which
+        case `'$FUEL_DATA_PATH/binarized_mnist/'` is used.
+
+    """
+    if save_path is None:
+        save_path = default_save_path
+    base_url = ('http://www.cs.toronto.edu/~larocheh/public/datasets/' +
+                'binarized_mnist/binarized_mnist_')
+    call(['curl', base_url + 'train.amat', '-o',
+          os.path.join(save_path, 'binarized_mnist_train.amat')])
+    call(['curl', base_url + 'valid.amat', '-o',
+          os.path.join(save_path, 'binarized_mnist_valid.amat')])
+    call(['curl', base_url + 'test.amat', '-o',
+          os.path.join(save_path, 'binarized_mnist_test.amat')])

--- a/fuel/downloaders/binarized_mnist.py
+++ b/fuel/downloaders/binarized_mnist.py
@@ -6,7 +6,7 @@ import fuel
 default_save_path = os.path.join(fuel.config.data_path, 'binarized_mnist')
 
 
-def binarized_mnist(save_path=None):
+def binarized_mnist(save_directory):
     """Downloads the binarized MNIST dataset files.
 
     The binarized MNIST dataset files
@@ -18,18 +18,15 @@ def binarized_mnist(save_path=None):
 
     Parameters
     ----------
-    save_path : str, optional
-        Where to save the downloaded files. Defaults to `None`, in which
-        case `'$FUEL_DATA_PATH/binarized_mnist/'` is used.
+    save_directory : str
+        Where to save the downloaded files.
 
     """
-    if save_path is None:
-        save_path = default_save_path
     base_url = ('http://www.cs.toronto.edu/~larocheh/public/datasets/' +
                 'binarized_mnist/binarized_mnist_')
     call(['curl', base_url + 'train.amat', '-o',
-          os.path.join(save_path, 'binarized_mnist_train.amat')])
+          os.path.join(save_directory, 'binarized_mnist_train.amat')])
     call(['curl', base_url + 'valid.amat', '-o',
-          os.path.join(save_path, 'binarized_mnist_valid.amat')])
+          os.path.join(save_directory, 'binarized_mnist_valid.amat')])
     call(['curl', base_url + 'test.amat', '-o',
-          os.path.join(save_path, 'binarized_mnist_test.amat')])
+          os.path.join(save_directory, 'binarized_mnist_test.amat')])

--- a/fuel/downloaders/binarized_mnist.py
+++ b/fuel/downloaders/binarized_mnist.py
@@ -1,6 +1,6 @@
 import os
 
-from fuel.downloaders.base import download
+from fuel.downloaders.base import default_manager
 
 
 def binarized_mnist(subparser):
@@ -19,24 +19,9 @@ def binarized_mnist(subparser):
         Subparser handling the `binarized_mnist` command.
 
     """
-    def download_binarized_mnist(args):
-        save_directory = args.directory
-        files = [os.path.join(save_directory,
-                              'binarized_mnist_{}.amat'.format(s))
-                 for s in ['train', 'valid', 'test']]
-        urls = ['http://www.cs.toronto.edu/~larocheh/public/datasets/' +
-                'binarized_mnist/binarized_mnist_{}.amat'.format(s)
-                for s in ['train', 'valid', 'test']]
-        if args.clear:
-            for f in files:
-                if os.path.isfile(f):
-                    os.remove(f)
-        else:
-            for url, f in zip(urls, files):
-                download(url, f)
-
-    subparser.add_argument("-d", "--directory", help="where to save the " +
-                           "downloaded files", type=str, default=os.getcwd())
-    subparser.add_argument("--clear", help="clear the downloaded files",
-                           action='store_true')
-    subparser.set_defaults(func=download_binarized_mnist)
+    sets = ['train', 'valid', 'test']
+    urls = ['http://www.cs.toronto.edu/~larocheh/public/datasets/' +
+            'binarized_mnist/binarized_mnist_{}.amat'.format(s) for s in sets]
+    filenames = ['binarized_mnist_{}.amat'.format(s) for s in sets]
+    subparser.set_defaults(
+        func=default_manager(urls=urls, filenames=filenames))

--- a/fuel/downloaders/binarized_mnist.py
+++ b/fuel/downloaders/binarized_mnist.py
@@ -1,12 +1,14 @@
 import os
+import shutil
 from subprocess import call
 
 import fuel
+from six.moves.urllib.request import urlopen
 
 default_save_path = os.path.join(fuel.config.data_path, 'binarized_mnist')
 
 
-def binarized_mnist(save_directory):
+def binarized_mnist(save_directory, clear=False):
     """Downloads the binarized MNIST dataset files.
 
     The binarized MNIST dataset files
@@ -20,13 +22,32 @@ def binarized_mnist(save_directory):
     ----------
     save_directory : str
         Where to save the downloaded files.
+    clear : bool, optional
+        If `True`, clear the downloaded files. Defaults to `False`.
 
     """
-    base_url = ('http://www.cs.toronto.edu/~larocheh/public/datasets/' +
-                'binarized_mnist/binarized_mnist_')
-    call(['curl', base_url + 'train.amat', '-o',
-          os.path.join(save_directory, 'binarized_mnist_train.amat')])
-    call(['curl', base_url + 'valid.amat', '-o',
-          os.path.join(save_directory, 'binarized_mnist_valid.amat')])
-    call(['curl', base_url + 'test.amat', '-o',
-          os.path.join(save_directory, 'binarized_mnist_test.amat')])
+    train_file = os.path.join(save_directory, 'binarized_mnist_train.amat')
+    valid_file = os.path.join(save_directory, 'binarized_mnist_valid.amat')
+    test_file = os.path.join(save_directory, 'binarized_mnist_test.amat')
+    if clear:
+        if os.path.isfile(train_file):
+            os.remove(train_file)
+        if os.path.isfile(valid_file):
+            os.remove(valid_file)
+        if os.path.isfile(test_file):
+            os.remove(test_file)
+    else:
+        base_url = ('http://www.cs.toronto.edu/~larocheh/public/datasets/' +
+                    'binarized_mnist/binarized_mnist_')
+        response = urlopen(base_url + 'train.amat')
+        with open(train_file, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+        response.close()
+        response = urlopen(base_url + 'valid.amat')
+        with open(valid_file, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+        response.close()
+        response = urlopen(base_url + 'test.amat')
+        with open(test_file, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+        response.close()

--- a/fuel/downloaders/binarized_mnist.py
+++ b/fuel/downloaders/binarized_mnist.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-from subprocess import call
 
 import fuel
 from six.moves.urllib.request import urlopen

--- a/fuel/downloaders/binarized_mnist.py
+++ b/fuel/downloaders/binarized_mnist.py
@@ -1,5 +1,3 @@
-import os
-
 from fuel.downloaders.base import default_manager
 
 

--- a/fuel/downloaders/binarized_mnist.py
+++ b/fuel/downloaders/binarized_mnist.py
@@ -1,4 +1,4 @@
-from fuel.downloaders.base import default_manager
+from fuel.downloaders.base import default_downloader
 
 
 def binarized_mnist(subparser):
@@ -22,4 +22,4 @@ def binarized_mnist(subparser):
             'binarized_mnist/binarized_mnist_{}.amat'.format(s) for s in sets]
     filenames = ['binarized_mnist_{}.amat'.format(s) for s in sets]
     subparser.set_defaults(
-        func=default_manager(urls=urls, filenames=filenames))
+        func=default_downloader, urls=urls, filenames=filenames)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     keywords='dataset data iteration pipeline processing',
     packages=find_packages(exclude=['tests']),
     install_requires=['six', 'picklable_itertools', 'toolz', 'pyyaml', 'h5py',
-                      'tables', 'urllib3'],
+                      'tables', 'urllib3', 'certifi'],
     scripts=['bin/fuel-convert', 'bin/fuel-download']
 )

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     keywords='dataset data iteration pipeline processing',
     packages=find_packages(exclude=['tests']),
     install_requires=['six', 'picklable_itertools', 'toolz', 'pyyaml', 'h5py',
-                      'tables'],
+                      'tables', 'urllib3'],
     scripts=['bin/fuel-convert', 'bin/fuel-download']
 )

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=['six', 'picklable_itertools', 'toolz', 'pyyaml', 'h5py',
                       'tables'],
-    scripts=['bin/fuel-convert']
+    scripts=['bin/fuel-convert', 'bin/fuel-download']
 )

--- a/tests/test_binarized_mnist.py
+++ b/tests/test_binarized_mnist.py
@@ -1,10 +1,13 @@
+import os
+
 from numpy.testing import assert_raises
 
+from fuel import config
 from fuel.datasets import BinarizedMNIST
 from tests import skip_if_not_available
 
 
-def test_binarized_mnist():
+def test_binarized_mnist_train():
     skip_if_not_available(datasets=['binarized_mnist'])
 
     mnist_train = BinarizedMNIST('train')
@@ -14,12 +17,20 @@ def test_binarized_mnist():
     assert mnist_train.num_examples == 50000
     mnist_train.close(handle)
 
+
+def test_binarized_mnist_valid():
+    skip_if_not_available(datasets=['binarized_mnist'])
+
     mnist_valid = BinarizedMNIST('valid')
     handle = mnist_valid.open()
     data = mnist_valid.get_data(handle, slice(0, 10000))[0]
     assert data.shape == (10000, 1, 28, 28)
     assert mnist_valid.num_examples == 10000
     mnist_valid.close(handle)
+
+
+def test_binarized_mnist_test():
+    skip_if_not_available(datasets=['binarized_mnist'])
 
     mnist_test = BinarizedMNIST('test')
     handle = mnist_test.open()
@@ -28,11 +39,11 @@ def test_binarized_mnist():
     assert mnist_test.num_examples == 10000
     mnist_test.close(handle)
 
+
+def test_binarized_mnist_invalid_split():
     assert_raises(ValueError, BinarizedMNIST, 'dummy')
 
-    mnist_test_flattened = BinarizedMNIST(
-        'test', flatten=['features'], load_in_memory=True)
-    handle = mnist_test_flattened.open()
-    data = mnist_test_flattened.get_data(handle, slice(0, 10000))[0]
-    assert data.shape == (10000, 784)
-    mnist_test_flattened.close(handle)
+
+def test_binarized_mnist_data_path():
+    assert BinarizedMNIST('train').data_path == os.path.join(
+        config.data_path, 'binarized_mnist.hdf5')

--- a/tests/test_binarized_mnist.py
+++ b/tests/test_binarized_mnist.py
@@ -7,6 +7,17 @@ from fuel.datasets import BinarizedMNIST
 from tests import skip_if_not_available
 
 
+def test_binarized_mnist_no_split():
+    skip_if_not_available(datasets=['binarized_mnist'])
+
+    dataset = BinarizedMNIST()
+    handle = dataset.open()
+    data = dataset.get_data(handle, slice(0, 70000))[0]
+    assert data.shape == (70000, 1, 28, 28)
+    assert dataset.num_examples == 70000
+    dataset.close(handle)
+
+
 def test_binarized_mnist_train():
     skip_if_not_available(datasets=['binarized_mnist'])
 
@@ -45,5 +56,5 @@ def test_binarized_mnist_invalid_split():
 
 
 def test_binarized_mnist_data_path():
-    assert BinarizedMNIST('train').data_path == os.path.join(
+    assert BinarizedMNIST().data_path == os.path.join(
         config.data_path, 'binarized_mnist.hdf5')

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,31 @@
+import h5py
+import numpy
+from numpy.testing import assert_equal
+
+from fuel.converters.base import fill_hdf5_file
+
+
+def test_fill_hdf5_file():
+    h5file = h5py.File(
+        'tmp.hdf5', mode="w", driver='core', backing_store=False)
+    train_features = numpy.arange(16, dtype='uint8').reshape((4, 2, 2))
+    test_features = numpy.arange(8, dtype='uint8').reshape((2, 2, 2)) + 3
+    train_targets = numpy.arange(4, dtype='float32').reshape((4, 1))
+    test_targets = numpy.arange(2, dtype='float32').reshape((2, 1)) + 3
+    data = ((train_features, test_features), (train_targets, test_targets))
+    source_names = ('features', 'targets')
+    shapes = ((6, 2, 2), (6, 1))
+    dtypes = ('uint8', 'float32')
+    split_names = ('train', 'test')
+    splits = ((0, 4), (4, 6))
+    fill_hdf5_file(
+        h5file, data, source_names, shapes, dtypes, split_names, splits)
+    assert_equal(h5file.attrs['train'], [0, 4])
+    assert_equal(h5file.attrs['test'], [4, 6])
+    assert_equal(
+        h5file['features'], numpy.vstack([train_features, test_features]))
+    assert_equal(
+        h5file['targets'], numpy.vstack([train_targets, test_targets]))
+    assert h5file['features'].dtype == 'uint8'
+    assert h5file['targets'].dtype == 'float32'
+    h5file.close()

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -1,0 +1,57 @@
+import os
+
+from fuel.downloaders.base import download, default_manager
+
+iris_url = ('https://archive.ics.uci.edu/ml/machine-learning-databases/' +
+            'iris/iris.data')
+iris_first_line = '5.1,3.5,1.4,0.2,Iris-setosa\n'
+
+
+def test_download_no_path():
+    download(iris_url)
+    with open('iris.data') as f:
+        first_line = f.readline()
+    assert first_line == iris_first_line
+    os.remove('iris.data')
+
+
+def test_download_path_is_dir():
+    os.mkdir('tmp')
+    download(iris_url, 'tmp')
+    with open('tmp/iris.data') as f:
+        first_line = f.readline()
+    assert first_line == iris_first_line
+    os.remove('tmp/iris.data')
+    os.rmdir('tmp')
+
+
+def test_download_path_is_file():
+    download(iris_url, 'iris_tmp.data')
+    with open('iris_tmp.data') as f:
+        first_line = f.readline()
+    assert first_line == iris_first_line
+    os.remove('iris_tmp.data')
+
+
+def test_default_manager_save():
+    class DummyArgs:
+        pass
+    args = DummyArgs()
+    args.directory = '.'
+    args.clear = False
+    default_manager([iris_url], ['iris.data'])(args)
+    with open('iris.data') as f:
+        first_line = f.readline()
+    assert first_line == iris_first_line
+    os.remove('iris.data')
+
+
+def test_default_manager_clear():
+    open('tmp.data', 'a').close()
+    class DummyArgs:
+        pass
+    args = DummyArgs()
+    args.directory = '.'
+    args.clear = True
+    default_manager([None], ['tmp.data'])(args)
+    assert not os.path.isfile('tmp.data')

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -8,6 +8,10 @@ iris_url = ('https://archive.ics.uci.edu/ml/machine-learning-databases/' +
 iris_hash = "6f608b71a7317216319b4d27b4d9bc84e6abd734eda7872b71a458569e2656c0"
 
 
+class DummyArgs:
+    pass
+
+
 def test_download_no_path():
     download(iris_url)
     with open('iris.data', 'r') as f:
@@ -32,8 +36,6 @@ def test_download_path_is_file():
 
 
 def test_default_manager_save():
-    class DummyArgs:
-        pass
     args = DummyArgs()
     args.directory = '.'
     args.clear = False
@@ -45,8 +47,6 @@ def test_default_manager_save():
 
 def test_default_manager_clear():
     open('tmp.data', 'a').close()
-    class DummyArgs:
-        pass
     args = DummyArgs()
     args.directory = '.'
     args.clear = True

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -15,7 +15,8 @@ class DummyArgs:
 def test_download_no_path():
     download(iris_url)
     with open('iris.data', 'r') as f:
-        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
+        assert hashlib.sha256(
+            f.read().encode('utf-8')).hexdigest() == iris_hash
     os.remove('iris.data')
 
 
@@ -23,7 +24,8 @@ def test_download_path_is_dir():
     os.mkdir('tmp')
     download(iris_url, 'tmp')
     with open('tmp/iris.data', 'r') as f:
-        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
+        assert hashlib.sha256(
+            f.read().encode('utf-8')).hexdigest() == iris_hash
     os.remove('tmp/iris.data')
     os.rmdir('tmp')
 
@@ -31,7 +33,8 @@ def test_download_path_is_dir():
 def test_download_path_is_file():
     download(iris_url, 'iris_tmp.data')
     with open('iris_tmp.data', 'r') as f:
-        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
+        assert hashlib.sha256(
+            f.read().encode('utf-8')).hexdigest() == iris_hash
     os.remove('iris_tmp.data')
 
 
@@ -41,7 +44,8 @@ def test_default_manager_save():
     args.clear = False
     default_manager([iris_url], ['iris.data'])(args)
     with open('iris.data', 'r') as f:
-        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
+        assert hashlib.sha256(
+            f.read().encode('utf-8')).hexdigest() == iris_hash
     os.remove('iris.data')
 
 

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -1,35 +1,33 @@
+import hashlib
 import os
 
 from fuel.downloaders.base import download, default_manager
 
 iris_url = ('https://archive.ics.uci.edu/ml/machine-learning-databases/' +
             'iris/iris.data')
-iris_first_line = '5.1,3.5,1.4,0.2,Iris-setosa\n'
+iris_hash = "6f608b71a7317216319b4d27b4d9bc84e6abd734eda7872b71a458569e2656c0"
 
 
 def test_download_no_path():
     download(iris_url)
-    with open('iris.data') as f:
-        first_line = f.readline()
-    assert first_line == iris_first_line
+    with open('iris.data', 'r') as f:
+        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
     os.remove('iris.data')
 
 
 def test_download_path_is_dir():
     os.mkdir('tmp')
     download(iris_url, 'tmp')
-    with open('tmp/iris.data') as f:
-        first_line = f.readline()
-    assert first_line == iris_first_line
+    with open('tmp/iris.data', 'r') as f:
+        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
     os.remove('tmp/iris.data')
     os.rmdir('tmp')
 
 
 def test_download_path_is_file():
     download(iris_url, 'iris_tmp.data')
-    with open('iris_tmp.data') as f:
-        first_line = f.readline()
-    assert first_line == iris_first_line
+    with open('iris_tmp.data', 'r') as f:
+        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
     os.remove('iris_tmp.data')
 
 
@@ -40,9 +38,8 @@ def test_default_manager_save():
     args.directory = '.'
     args.clear = False
     default_manager([iris_url], ['iris.data'])(args)
-    with open('iris.data') as f:
-        first_line = f.readline()
-    assert first_line == iris_first_line
+    with open('iris.data', 'r') as f:
+        assert hashlib.sha256(f.read()).hexdigest() == iris_hash
     os.remove('iris.data')
 
 

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -1,7 +1,7 @@
 import hashlib
 import os
 
-from fuel.downloaders.base import download, default_manager
+from fuel.downloaders.base import download, default_downloader
 
 iris_url = ('https://archive.ics.uci.edu/ml/machine-learning-databases/' +
             'iris/iris.data')
@@ -9,7 +9,9 @@ iris_hash = "6f608b71a7317216319b4d27b4d9bc84e6abd734eda7872b71a458569e2656c0"
 
 
 class DummyArgs:
-    pass
+    def __init__(self, **kwargs):
+        for key, val in kwargs.items():
+            setattr(self, key, val)
 
 
 def test_download_no_path():
@@ -38,21 +40,19 @@ def test_download_path_is_file():
     os.remove('iris_tmp.data')
 
 
-def test_default_manager_save():
-    args = DummyArgs()
-    args.directory = '.'
-    args.clear = False
-    default_manager([iris_url], ['iris.data'])(args)
+def test_default_downloader_save():
+    args = DummyArgs(
+        directory='.', clear=False, urls=[iris_url], filenames=['iris.data'])
+    default_downloader(args)
     with open('iris.data', 'r') as f:
         assert hashlib.sha256(
             f.read().encode('utf-8')).hexdigest() == iris_hash
     os.remove('iris.data')
 
 
-def test_default_manager_clear():
+def test_default_downloader_clear():
     open('tmp.data', 'a').close()
-    args = DummyArgs()
-    args.directory = '.'
-    args.clear = True
-    default_manager([None], ['tmp.data'])(args)
+    args = DummyArgs(
+        directory='.', clear=True, urls=[None], filenames=['tmp.data'])
+    default_downloader(args)
     assert not os.path.isfile('tmp.data')

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -9,7 +9,7 @@ from fuel.downloaders.base import (download, default_downloader,
 
 iris_url = ('https://archive.ics.uci.edu/ml/machine-learning-databases/' +
             'iris/iris.data')
-iris_hash = "6f608b71a7317216319b4d27b4d9bc84e6abd734eda7872b71a458569e2656c0"
+iris_hash = "42615765a885ddf54427f12c34a0a070"
 
 
 class DummyArgs:
@@ -26,7 +26,7 @@ def test_download():
     f = tempfile.SpooledTemporaryFile()
     download(iris_url, f)
     f.seek(0)
-    assert hashlib.sha256(f.read()).hexdigest() == iris_hash
+    assert hashlib.md5(f.read()).hexdigest() == iris_hash
     f.close()
 
 
@@ -43,7 +43,7 @@ class TestDefaultDownloader(TestCase):
                          filenames=['iris.data'])
         default_downloader(args)
         with open(iris_path, 'r') as f:
-            assert hashlib.sha256(
+            assert hashlib.md5(
                 f.read().encode('utf-8')).hexdigest() == iris_hash
         os.remove(iris_path)
 
@@ -53,7 +53,7 @@ class TestDefaultDownloader(TestCase):
                          filenames=[None])
         default_downloader(args)
         with open(iris_path, 'r') as f:
-            assert hashlib.sha256(
+            assert hashlib.md5(
                 f.read().encode('utf-8')).hexdigest() == iris_hash
         os.remove(iris_path)
 

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -26,7 +26,7 @@ def test_download():
     f = tempfile.SpooledTemporaryFile()
     download(iris_url, f)
     f.seek(0)
-    assert hashlib.sha256(f.read().encode('utf-8')).hexdigest() == iris_hash
+    assert hashlib.sha256(f.read()).hexdigest() == iris_hash
     f.close()
 
 


### PR DESCRIPTION
This PR introduces a `fuel-download` script to download built-in datasets.

Its implementation is similar to `fuel-convert`'s implementation: the script allows to choose amongst the download functions listed in `fuel.downloaders.__all__`.

I changed the default location to the current working directory following a discussion in #54.

The workflow for downloading a built-in dataset now looks like this:

```
cd $FUEL_DATA_PATH
fuel-download mnist
fuel-convert mnist
```