### PR TITLE
Add `Spiral` toy dataset

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,12 @@
+API Reference
+=============
+
+.. warning::
+
+   This API reference is currently nothing but a dump of docstrings, ordered
+   alphabetically.
+
+.. toctree::
+    :glob:
+
+    *

--- a/docs/api/toy-datasets.rst
+++ b/docs/api/toy-datasets.rst
@@ -1,0 +1,8 @@
+Toy datasets 
+============
+
+.. automodule:: fuel.datasets.toy
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,8 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.graphviz',
-    'sphinx.ext.intersphinx'
+    'sphinx.ext.intersphinx',
+    'matplotlib.sphinxext.plot_directive',
 ]
 
 intersphinx_mapping = {

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@ Welcome to Fuel's documentation!
 
    overview
    h5py_dataset
+   api/index
 
 Fuel is a data pipeline framework which provides your machine learning models
 with the data they need. It is planned to be used by both the Blocks_ and

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -16,10 +16,10 @@ class Spiral(IndexableDataset):
 
         from fuel.datasets.toy import Spiral
 
-        ds = Spiral()
-        features, position = ds.get_data(None, slice(0, 100))
+        ds = Spiral(classes=3)
+        features, position, label = ds.get_data(None, slice(0, 500))
 
-        plt.title("Datapoints drawn from Spiral(classes=2)")
+        plt.title("Datapoints drawn from Spiral(classes=3)")
         plt.scatter(features[:,0], features[:,1], c=position)
         plt.xlim(-1.2, 1.2)
         plt.ylim(-1.2, 1.2)
@@ -32,19 +32,23 @@ class Spiral(IndexableDataset):
     cycles : float
     sd : float
     """
-    def __init__(self, n_datapoints=1000, cycles=1., sd=0.0, **kwargs):
+    def __init__(self, n_datapoints=1000, classes=1, cycles=1., sd=0.0, **kwargs):
         # Create dataset
         pos = numpy.random.uniform(size=(n_datapoints,), low=0, high=cycles)
+        label = numpy.random.randint(size=(n_datapoints,), low=0, high=classes)
+
         radius = (2*pos+1) / 3.
+        phase_offset = label * (2*numpy.pi) / classes
         
         features = numpy.zeros(shape=(n_datapoints, 2), dtype='float32')
 
-        features[:,0] = radius * numpy.sin(2*numpy.pi*pos)
-        features[:,1] = radius * numpy.cos(2*numpy.pi*pos)
+        features[:,0] = radius * numpy.sin(2*numpy.pi*pos + phase_offset)
+        features[:,1] = radius * numpy.cos(2*numpy.pi*pos + phase_offset)
 
         data = OrderedDict([
             ('features', features),
             ('position', pos),
+            ('label', label),
         ])
 
         super(Spiral, self).__init__(data, **kwargs)

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -15,7 +15,7 @@ class Spiral(IndexableDataset):
     Parameters
     ----------
     n_datapoints : int
-        Number of datapoints to draw
+        Number of datapoints to create
     cycles : float
     sd : float
     """
@@ -29,9 +29,9 @@ class Spiral(IndexableDataset):
         features[:,0] = radius * numpy.sin(2*numpy.pi*pos)
         features[:,1] = radius * numpy.cos(2*numpy.pi*pos)
 
-        data = OrderedDict(
+        data = OrderedDict([
             ('features', features),
             ('position', pos),
-        )
+        ])
 
         super(Spiral, self).__init__(data, **kwargs)

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+import numpy 
+
+from collections import OrderedDict
+
+from fuel import config
+from fuel.datasets import IndexableDataset
+from fuel.utils import do_not_pickle_attributes
+
+
+class Spiral(IndexableDataset):
+    u"""Simple toy dataset containing datapoints from a spiral on a 2d plane.
+
+    Parameters
+    ----------
+    n_datapoints : int
+        Number of datapoints to draw
+    cycles : float
+    sd : float
+    """
+    def __init__(self, n_datapoints=1000, cycles=1., sd=0.0, **kwargs):
+        # Create dataset
+        pos = numpy.random.uniform(size=(n_datapoints,), low=0, high=cycles)
+        radius = (2*pos+1) / 3.
+        
+        features = numpy.zeros(shape=(n_datapoints, 2), dtype='float32')
+
+        features[:,0] = radius * numpy.sin(2*numpy.pi*pos)
+        features[:,1] = radius * numpy.cos(2*numpy.pi*pos)
+
+        data = OrderedDict(
+            ('features', features),
+            ('position', pos),
+        )
+
+        super(Spiral, self).__init__(data, **kwargs)

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -8,7 +8,13 @@ from fuel.datasets import IndexableDataset
 
 
 class Spiral(IndexableDataset):
-    u"""Simple toy dataset containing datapoints from a spiral on a 2d plane.
+    u"""Toy dataset containing points sampled from spirals on a 2d plane.
+
+    The dataset contains 3 sources:
+
+    * features -- the (x, y) position of the datapoints
+    * position -- the relative position on the spiral arm
+    * label -- the class labels (spiral arm)
 
     .. plot::
 
@@ -18,17 +24,28 @@ class Spiral(IndexableDataset):
         features, position, label = ds.get_data(None, slice(0, 500))
 
         plt.title("Datapoints drawn from Spiral(classes=3)")
-        plt.scatter(features[:,0], features[:,1], c=position)
+        for l, m in enumerate(['o', '^', 'v']):
+            mask = label == l
+            plt.scatter(features[mask,0], features[mask,1],
+                        c=position[mask], marker=m, label="label==%d"%l)
         plt.xlim(-1.2, 1.2)
         plt.ylim(-1.2, 1.2)
+        plt.legend()
+        plt.colorbar()
+        plt.xlabel("features[:,0]")
+        plt.ylabel("features[:,1]")
         plt.show()
 
     Parameters
     ----------
     n_datapoints : int
         Number of datapoints to create
+    classes : int
+        Number of spiral arms
     cycles : float
     sd : float
+        Normal distributed noise with standard deviation *ds* is added to the
+        features.
     """
     def __init__(self, n_datapoints=1000, classes=1, cycles=1., sd=0.0,
                  **kwargs):

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -12,6 +12,19 @@ from fuel.utils import do_not_pickle_attributes
 class Spiral(IndexableDataset):
     u"""Simple toy dataset containing datapoints from a spiral on a 2d plane.
 
+    .. plot::
+
+        from fuel.datasets.toy import Spiral
+
+        ds = Spiral()
+        features, position = ds.get_data(None, slice(0, 100))
+
+        plt.title("Datapoints drawn from Spiral(classes=2)")
+        plt.scatter(features[:,0], features[:,1], c=position)
+        plt.xlim(-1.2, 1.2)
+        plt.ylim(-1.2, 1.2)
+        plt.show()
+
     Parameters
     ----------
     n_datapoints : int

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -61,6 +61,7 @@ class Spiral(IndexableDataset):
 
         features[:, 0] = radius * numpy.sin(2*numpy.pi*pos + phase_offset)
         features[:, 1] = radius * numpy.cos(2*numpy.pi*pos + phase_offset)
+        features += noise * numpy.random.normal(size=(num_examples, 2))
 
         data = OrderedDict([
             ('features', features),

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -39,15 +39,16 @@ class Spiral(IndexableDataset):
     Parameters
     ----------
     num_examples : int
-        Number of datapoints to create
+        Number of datapoints to create.
     classes : int
-        Number of spiral arms
+        Number of spiral arms.
     cycles : float
-    sd : float
-        Add normal distributed noise with standard deviation *ds*.
+        Number of turns the arms take.
+    noise : float
+        Add normal distributed noise with standard deviation *noise*.
 
     """
-    def __init__(self, num_examples=1000, classes=1, cycles=1., sd=0.0,
+    def __init__(self, num_examples=1000, classes=1, cycles=1., noise=0.0,
                  **kwargs):
         # Create dataset
         pos = numpy.random.uniform(size=num_examples, low=0, high=cycles)

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -69,3 +69,70 @@ class Spiral(IndexableDataset):
         ])
 
         super(Spiral, self).__init__(data, **kwargs)
+
+
+class SwissRoll(IndexableDataset):
+    """Dataset containing points from a 3-dimensional Swiss roll.
+
+    The dataset contains 2 sources:
+
+    * features -- the x, y and z position of the datapoints
+    * position -- radial and z position on the manifold
+
+    .. plot::
+
+        from fuel.datasets.toy import SwissRoll
+        import mpl_toolkits.mplot3d.axes3d as p3
+        import numpy as np
+
+        ds = SwissRoll()
+        features, pos = ds.get_data(None, slice(0, 1000))
+
+        color = pos[:,0]
+        color -= color.min()
+        color /= color.max()
+
+        fig = plt.figure()
+        ax = fig.gca(projection="3d")
+        ax.scatter(features[:,0], features[:,1], features[:,2], 'x', c=color)
+        ax.set_xlim(-1, 1)
+        ax.set_ylim(-1, 1)
+        ax.set_zlim(-1, 1)
+        ax.view_init(10., 10.)
+        plt.show()
+
+    Parameters
+    ----------
+    num_examples : int
+        Number of datapoints to create.
+    noise : float
+        Add normal distributed noise with standard deviation *noise*.
+
+    """
+    def __init__(self, num_examples=1000, noise=0.0, **kwargs):
+        cycles = 1.5
+
+        pos = numpy.random.uniform(size=num_examples, low=0, high=1)
+        phi = cycles * numpy.pi * (1 + 2*pos)
+        radius = (1+2*pos) / 3
+
+        x = radius * numpy.cos(phi)
+        y = radius * numpy.sin(phi)
+        z = numpy.random.uniform(size=num_examples, low=-1, high=1)
+
+        features = numpy.zeros(shape=(num_examples, 3), dtype='float32')
+        features[:, 0] = x
+        features[:, 1] = y
+        features[:, 2] = z
+        features += noise * numpy.random.normal(size=(num_examples, 3))
+
+        position = numpy.zeros(shape=(num_examples, 2), dtype='float32')
+        position[:, 0] = pos
+        position[:, 1] = z
+
+        data = OrderedDict([
+            ('features', features),
+            ('position', position),
+        ])
+
+        super(SwissRoll, self).__init__(data, **kwargs)

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -95,7 +95,8 @@ class SwissRoll(IndexableDataset):
 
         fig = plt.figure()
         ax = fig.gca(projection="3d")
-        ax.scatter(features[:,0], features[:,1], features[:,2], 'x', c=color)
+        ax.scatter(features[:,0], features[:,1], features[:,2],
+                   'x', c=color)
         ax.set_xlim(-1, 1)
         ax.set_ylim(-1, 1)
         ax.set_zlim(-1, 1)

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import numpy 
+import numpy
 
 from collections import OrderedDict
 
-from fuel import config
 from fuel.datasets import IndexableDataset
-from fuel.utils import do_not_pickle_attributes
 
 
 class Spiral(IndexableDataset):
@@ -32,18 +30,19 @@ class Spiral(IndexableDataset):
     cycles : float
     sd : float
     """
-    def __init__(self, n_datapoints=1000, classes=1, cycles=1., sd=0.0, **kwargs):
+    def __init__(self, n_datapoints=1000, classes=1, cycles=1., sd=0.0,
+                 **kwargs):
         # Create dataset
-        pos = numpy.random.uniform(size=(n_datapoints,), low=0, high=cycles)
-        label = numpy.random.randint(size=(n_datapoints,), low=0, high=classes)
+        pos = numpy.random.uniform(size=n_datapoints, low=0, high=cycles)
+        label = numpy.random.randint(size=n_datapoints, low=0, high=classes)
 
         radius = (2*pos+1) / 3.
         phase_offset = label * (2*numpy.pi) / classes
-        
+
         features = numpy.zeros(shape=(n_datapoints, 2), dtype='float32')
 
-        features[:,0] = radius * numpy.sin(2*numpy.pi*pos + phase_offset)
-        features[:,1] = radius * numpy.cos(2*numpy.pi*pos + phase_offset)
+        features[:, 0] = radius * numpy.sin(2*numpy.pi*pos + phase_offset)
+        features[:, 1] = radius * numpy.cos(2*numpy.pi*pos + phase_offset)
 
         data = OrderedDict([
             ('features', features),

--- a/fuel/datasets/toy.py
+++ b/fuel/datasets/toy.py
@@ -38,25 +38,25 @@ class Spiral(IndexableDataset):
 
     Parameters
     ----------
-    n_datapoints : int
+    num_examples : int
         Number of datapoints to create
     classes : int
         Number of spiral arms
     cycles : float
     sd : float
-        Normal distributed noise with standard deviation *ds* is added to the
-        features.
+        Add normal distributed noise with standard deviation *ds*.
+
     """
-    def __init__(self, n_datapoints=1000, classes=1, cycles=1., sd=0.0,
+    def __init__(self, num_examples=1000, classes=1, cycles=1., sd=0.0,
                  **kwargs):
         # Create dataset
-        pos = numpy.random.uniform(size=n_datapoints, low=0, high=cycles)
-        label = numpy.random.randint(size=n_datapoints, low=0, high=classes)
+        pos = numpy.random.uniform(size=num_examples, low=0, high=cycles)
+        label = numpy.random.randint(size=num_examples, low=0, high=classes)
 
         radius = (2*pos+1) / 3.
         phase_offset = label * (2*numpy.pi) / classes
 
-        features = numpy.zeros(shape=(n_datapoints, 2), dtype='float32')
+        features = numpy.zeros(shape=(num_examples, 2), dtype='float32')
 
         features[:, 0] = radius * numpy.sin(2*numpy.pi*pos + phase_offset)
         features[:, 1] = radius * numpy.cos(2*numpy.pi*pos + phase_offset)

--- a/tests/test_toy.py
+++ b/tests/test_toy.py
@@ -1,0 +1,16 @@
+
+from fuel.datasets.toy import Spiral
+
+
+def test_spiral():
+    ds = Spiral(num_examples=1000, classes=2)
+
+    features, position, label = ds.get_data(None, slice(0, 1000))
+
+    assert features.shape[0] == 1000
+    assert position.shape[0] == 1000
+    assert label.shape[0] == 1000
+
+    assert features.max() <= 1.
+    assert position.max() <= 1.
+    assert label.max() == 2

--- a/tests/test_toy.py
+++ b/tests/test_toy.py
@@ -1,5 +1,5 @@
 
-from fuel.datasets.toy import Spiral
+from fuel.datasets.toy import Spiral, SwissRoll
 
 
 def test_spiral():
@@ -7,10 +7,32 @@ def test_spiral():
 
     features, position, label = ds.get_data(None, slice(0, 1000))
 
+    assert features.ndim == 2
     assert features.shape[0] == 1000
+    assert features.shape[1] == 2
+
+    assert position.ndim == 1
     assert position.shape[0] == 1000
+
+    assert label.ndim == 1
     assert label.shape[0] == 1000
 
     assert features.max() <= 1.
     assert position.max() <= 1.
-    assert label.max() == 2
+    assert label.max() == 1
+
+def test_swiossroll():
+    ds = SwissRoll(num_examples=1000)
+
+    features, position = ds.get_data(None, slice(0, 1000))
+
+    assert features.ndim == 2
+    assert features.shape[0] == 1000
+    assert features.shape[1] == 3
+
+    assert position.ndim == 2
+    assert position.shape[0] == 1000
+    assert position.shape[1] == 2
+
+    assert features.max() <= 1.
+    assert position.max() <= 1.

--- a/tests/test_toy.py
+++ b/tests/test_toy.py
@@ -21,6 +21,7 @@ def test_spiral():
     assert position.max() <= 1.
     assert label.max() == 1
 
+
 def test_swiossroll():
     ds = SwissRoll(num_examples=1000)
 


### PR DESCRIPTION
This adds a simple, 2-dimensional "Spiral" toy dataset.

I think simple datasets like this are valuable in certain situations and we might want to include a few (e.g. swiss-roll, etc.).

In the case we want to merge this:

* should the module be called `fuel.datasets.toy`? Or rather `fuel.datasets.small`? Or something else?
* this PR activates the `matplotlib.sphinxext.plot_directive` Sphinx extension to visualize the dataset in the documentation. I believe a visualization is helpfull here. Is this something we want? 