### PR TITLE
Merge transformer returns iterator with dictionary

### DIFF
--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -2,7 +2,7 @@ from abc import ABCMeta
 from multiprocessing import Process, Queue
 
 import numpy
-from picklable_itertools import chain, ifilter, izip
+from picklable_itertools import chain, ifilter, izip, imap
 from picklable_itertools.extras import partition
 from six import add_metaclass
 
@@ -420,7 +420,22 @@ class Merge(Transformer):
         batches = chain.from_iterable(
             izip(*[data_stream.get_epoch_iterator()
                    for data_stream in self.data_streams]))
-        return partition(len(self.sources), chain.from_iterable(batches))
+
+        part = partition(len(self.sources), chain.from_iterable(batches))
+        as_dict = kwargs.get('as_dict', False)
+        if as_dict:
+            return imap(make_dict(self.sources), part)
+        else:
+            return part
+
+
+class make_dict(object):
+
+    def __init__(self, sources):
+        self.sources = sources
+
+    def __call__(self, x):
+        return dict(izip(self.sources, x))
 
 
 class BackgroundProcess(object):

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -2,7 +2,7 @@ from abc import ABCMeta
 from multiprocessing import Process, Queue
 
 import numpy
-from picklable_itertools import chain, ifilter, izip, imap
+from picklable_itertools import chain, ifilter, izip, imap, repeat, starmap
 from picklable_itertools.extras import partition
 from six import add_metaclass
 
@@ -424,18 +424,9 @@ class Merge(Transformer):
         part = partition(len(self.sources), chain.from_iterable(batches))
         as_dict = kwargs.get('as_dict', False)
         if as_dict:
-            return imap(make_dict(self.sources), part)
+            return imap(dict, starmap(zip, izip(repeat(self.sources), part)))
         else:
             return part
-
-
-class make_dict(object):
-
-    def __init__(self, sources):
-        self.sources = sources
-
-    def __call__(self, x):
-        return dict(izip(self.sources, x))
 
 
 class BackgroundProcess(object):


### PR DESCRIPTION
Merge transformer is now able to return iterator in dictionary form. You can probably avoid making a separate class/function to create the dictionary, but didn't really know how to do it. 