### PR TITLE
[WIP] Add axis labels to data streams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
         cd -
       fi
   # With Fuel installed we can install Blocks
-  - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt
+  - pip install -e git+git://github.com/vdumoulin/blocks.git@fuel_pr_83#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt
   # Run the Blocks test to make sure we didn't break anything
   - bokeh-server &> /dev/null &
   - nose2 tests --start-dir $HOME/blocks

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
         cd -
       fi
   # With Fuel installed we can install Blocks
-  - pip install -e git+git://github.com/vdumoulin/blocks.git@fuel_pr_83#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt
+  - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt
   # Run the Blocks test to make sure we didn't break anything
   - bokeh-server &> /dev/null &
   - nose2 tests --start-dir $HOME/blocks

--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -46,7 +46,7 @@ class Dataset(object):
     """
     provides_sources = None
 
-    def __init__(self, sources=None):
+    def __init__(self, sources=None, axis_labels=None):
         if not self.provides_sources:
             raise ValueError("dataset does not have `provides_sources`")
         if sources is not None:
@@ -54,6 +54,7 @@ class Dataset(object):
                                       for source in sources):
                 raise ValueError("unable to provide requested sources")
             self.sources = sources
+        self._axis_labels = axis_labels
 
     @property
     def sources(self):
@@ -64,6 +65,14 @@ class Dataset(object):
     @sources.setter
     def sources(self, sources):
         self._sources = sources
+
+    @property
+    def axis_labels(self):
+        return self._axis_labels
+
+    @axis_labels.setter
+    def axis_labels(self, axis_labels):
+        self._axis_labels = axis_labels
 
     @property
     def example_iteration_scheme(self):

--- a/fuel/datasets/base.py
+++ b/fuel/datasets/base.py
@@ -54,7 +54,7 @@ class Dataset(object):
                                       for source in sources):
                 raise ValueError("unable to provide requested sources")
             self.sources = sources
-        self._axis_labels = axis_labels
+        self.axis_labels = axis_labels
 
     @property
     def sources(self):
@@ -65,14 +65,6 @@ class Dataset(object):
     @sources.setter
     def sources(self, sources):
         self._sources = sources
-
-    @property
-    def axis_labels(self):
-        return self._axis_labels
-
-    @axis_labels.setter
-    def axis_labels(self, axis_labels):
-        self._axis_labels = axis_labels
 
     @property
     def example_iteration_scheme(self):

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -36,8 +36,9 @@ class AbstractDataStream(object):
         given by the dataset.
 
     """
-    def __init__(self, iteration_scheme=None):
+    def __init__(self, iteration_scheme=None, axis_labels=None):
         self.iteration_scheme = iteration_scheme
+        self.axis_labels = axis_labels
 
     def get_data(self, request=None):
         """Request data from the dataset or the wrapped stream.
@@ -49,11 +50,6 @@ class AbstractDataStream(object):
 
         """
         pass
-
-    @property
-    def axis_labels(self):
-        """Returns a dict mapping sources to axis labels."""
-        return None
 
     @abstractmethod
     def reset(self):
@@ -106,6 +102,7 @@ class DataStream(AbstractDataStream):
 
     """
     def __init__(self, dataset, **kwargs):
+        kwargs.setdefault('axis_labels', dataset.axis_labels)
         super(DataStream, self).__init__(**kwargs)
         self.dataset = dataset
         self.data_state = self.dataset.open()
@@ -120,10 +117,6 @@ class DataStream(AbstractDataStream):
     @sources.setter
     def sources(self, value):
         self._sources = value
-
-    @property
-    def axis_labels(self):
-        return self.dataset.axis_labels
 
     def close(self):
         self.data_state = self.dataset.close(self.data_state)

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -50,6 +50,11 @@ class AbstractDataStream(object):
         """
         pass
 
+    @property
+    def axis_labels(self):
+        """Returns a dict mapping sources to axis labels."""
+        return None
+
     @abstractmethod
     def reset(self):
         """Reset the data stream."""
@@ -115,6 +120,13 @@ class DataStream(AbstractDataStream):
     @sources.setter
     def sources(self, value):
         self._sources = value
+
+    @property
+    def axis_labels(self):
+        if hasattr(self.dataset.axis_labels):
+            return self.dataset.axis_labels
+        else:
+            return None
 
     def close(self):
         self.data_state = self.dataset.close(self.data_state)

--- a/fuel/streams.py
+++ b/fuel/streams.py
@@ -123,10 +123,7 @@ class DataStream(AbstractDataStream):
 
     @property
     def axis_labels(self):
-        if hasattr(self.dataset.axis_labels):
-            return self.dataset.axis_labels
-        else:
-            return None
+        return self.dataset.axis_labels
 
     def close(self):
         self.data_state = self.dataset.close(self.data_state)

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -26,14 +26,10 @@ class Transformer(AbstractDataStream):
         is working on example or batch
 
     """
-    def __init__(self, data_stream, batch_input=False,  **kwargs):
+    def __init__(self, data_stream, batch_input=False, **kwargs):
         super(Transformer, self).__init__(**kwargs)
         self.data_stream = data_stream
         self.batch_input = batch_input
-
-    @property
-    def axis_labels(self):
-        return None
 
     @property
     def sources(self):
@@ -124,11 +120,8 @@ class Mapping(Transformer):
 class ForceFloatX(Transformer):
     """Force all floating point numpy arrays to be floatX."""
     def __init__(self, data_stream):
-        super(ForceFloatX, self).__init__(data_stream)
-
-    @property
-    def axis_labels(self):
-        return self.data_stream.axis_labels
+        super(ForceFloatX, self).__init__(
+            data_stream, axis_labels=data_stream.axis_labels)
 
     def get_data(self, request=None):
         if request is not None:

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -128,11 +128,7 @@ class ForceFloatX(Transformer):
 
     @property
     def axis_labels(self):
-        return None
-        if hasattr(self.data_stream.axis_labels):
-            return self.data_stream.axis_labels
-        else:
-            return None
+        return self.data_stream.axis_labels
 
     def get_data(self, request=None):
         if request is not None:

--- a/fuel/transformers/__init__.py
+++ b/fuel/transformers/__init__.py
@@ -32,6 +32,10 @@ class Transformer(AbstractDataStream):
         self.batch_input = batch_input
 
     @property
+    def axis_labels(self):
+        return None
+
+    @property
     def sources(self):
         if hasattr(self, '_sources'):
             return self._sources
@@ -121,6 +125,14 @@ class ForceFloatX(Transformer):
     """Force all floating point numpy arrays to be floatX."""
     def __init__(self, data_stream):
         super(ForceFloatX, self).__init__(data_stream)
+
+    @property
+    def axis_labels(self):
+        return None
+        if hasattr(self.data_stream.axis_labels):
+            return self.data_stream.axis_labels
+        else:
+            return None
 
     def get_data(self, request=None):
         if request is not None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -31,10 +31,21 @@ def test_dataset():
     assert next(stream.get_epoch_iterator(as_dict=True)) == {"data": 1}
 
 
+def test_dataset_no_axis_labels():
+    dataset = IterableDataset(numpy.eye(2))
+    assert dataset.axis_labels == None
+
+
 def test_dataset_axis_labels():
     axis_labels = {'data': ('batch', 'features')}
     dataset = IterableDataset(numpy.eye(2), axis_labels=axis_labels)
     assert dataset.axis_labels == axis_labels
+
+
+def test_data_stream_no_axis_labels():
+    dataset = IterableDataset(numpy.eye(2))
+    stream = DataStream(dataset)
+    assert stream.axis_labels == None
 
 
 def test_data_stream_axis_labels():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -33,7 +33,7 @@ def test_dataset():
 
 def test_dataset_no_axis_labels():
     dataset = IterableDataset(numpy.eye(2))
-    assert dataset.axis_labels == None
+    assert dataset.axis_labels is None
 
 
 def test_dataset_axis_labels():
@@ -45,7 +45,7 @@ def test_dataset_axis_labels():
 def test_data_stream_no_axis_labels():
     dataset = IterableDataset(numpy.eye(2))
     stream = DataStream(dataset)
-    assert stream.axis_labels == None
+    assert stream.axis_labels is None
 
 
 def test_data_stream_axis_labels():

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -158,6 +158,7 @@ def test_data_driven_epochs():
         sources = ('data',)
 
         def __init__(self):
+            self.axis_labels = None
             self.data = [[1, 2, 3, 4],
                          [5, 6, 7, 8]]
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -31,6 +31,19 @@ def test_dataset():
     assert next(stream.get_epoch_iterator(as_dict=True)) == {"data": 1}
 
 
+def test_dataset_axis_labels():
+    axis_labels = {'data': ('batch', 'features')}
+    dataset = IterableDataset(numpy.eye(2), axis_labels=axis_labels)
+    assert dataset.axis_labels == axis_labels
+
+
+def test_data_stream_axis_labels():
+    axis_labels = {'data': ('batch', 'features')}
+    dataset = IterableDataset(numpy.eye(2), axis_labels=axis_labels)
+    stream = DataStream(dataset)
+    assert stream.axis_labels == axis_labels
+
+
 def test_data_stream_mapping():
     data = [1, 2, 3]
     data_doubled = [2, 4, 6]
@@ -106,6 +119,14 @@ def test_floatx():
     data = next(ForceFloatX(DataStream(dataset)).get_epoch_iterator())
     assert str(data[0].dtype) == floatX
     assert str(data[1].dtype) == "int64"
+
+
+def test_floatx_axis_labels():
+    x = numpy.eye(2).astype('float64')
+    axis_labels = {'x': ('batch', 'feature')}
+    dataset = IterableDataset({'x': x}, axis_labels=axis_labels)
+    stream = ForceFloatX(DataStream(dataset))
+    assert stream.axis_labels == axis_labels
 
 
 def test_sources_selection():

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -42,8 +42,8 @@ def test_h5py_dataset_split_parsing():
         features[...] = numpy.zeros(shape=(100, 36)).astype('uint8')
         targets = h5file.create_dataset('targets', (30, 1), dtype='uint8')
         targets[...] = numpy.zeros(shape=(30, 1)).astype('uint8')
-        split_dict = {'train': {'features': (0, 20), 'targets': (0, 20)},
-                      'test': {'features': (20, 30), 'targets': (20, 30)},
+        split_dict = {'train': {'features': (0, 20, '.'), 'targets': (0, 20)},
+                      'test': {'features': (20, 30, ''), 'targets': (20, 30)},
                       'unlabeled': {'features': (30, 100)}}
         h5file.attrs['split'] = H5PYDataset.create_split_array(split_dict)
         h5file.flush()


### PR DESCRIPTION
I'm starting the PR early to get comments on the approach I've chosen (in particular from @lamblin @dwf @bartvm).

The `axis_labels` attribute (defaulting to `None`) is introduced in `Dataset` and `AbstractDataStream`. Like in `H5PYDataset`, this attribute should be a dict mapping source name to tuple of axis labels.

By convention, if a source doesn't appear in `axis_labels`, it means there's no axis label for this source (or, equivalently, its label is `''`). `None` is treated as an empty dict.

`Transformer` subclasses replace the `axis_labels` attribute of their wrapped data stream by `None` by default, because we can't know what a transformation will do to the axis semantics. Subclasses can override that property; as an example, I've implemented the property for `ForceFloatX`, which trivially passes its wrapped data stream's `axis_labels` attribute.