### PR TITLE
Make doctests work with Python 2/3 string outputs

### DIFF
--- a/docs/h5py_dataset.rst
+++ b/docs/h5py_dataset.rst
@@ -248,17 +248,17 @@ node of the HDF5 file, and :class:`~.datasets.hdf5.H5PYDataset` automatically
 picked them up for us:
 
 >>> print(train_set.provides_sources)
-(u'image_features', u'targets', u'vector_features')
+('image_features', 'targets', 'vector_features')
 
 It also parsed axis labels, which are accessible through the ``axis_labels``
 property, which is a dict mapping source names to a tuple of axis labels:
 
 >>> print(train_set.axis_labels['image_features'])
-(u'batch', u'channel', u'height', u'width')
+('batch', 'channel', 'height', 'width')
 >>> print(train_set.axis_labels['vector_features'])
-(u'batch', u'feature')
+('batch', 'feature')
 >>> print(train_set.axis_labels['targets'])
-(u'batch', u'index')
+('batch', 'index')
 
 We can request data as usual:
 

--- a/docs/h5py_dataset.rst
+++ b/docs/h5py_dataset.rst
@@ -247,18 +247,18 @@ The available data sources are defined by the names of the datasets in the root
 node of the HDF5 file, and :class:`~.datasets.hdf5.H5PYDataset` automatically
 picked them up for us:
 
->>> print(train_set.provides_sources) # doctest: +SKIP
-['image_features', 'targets', 'vector_features']
+>>> print(train_set.provides_sources)
+(u'image_features', u'targets', u'vector_features')
 
 It also parsed axis labels, which are accessible through the ``axis_labels``
 property, which is a dict mapping source names to a tuple of axis labels:
 
->>> print(train_set.axis_labels['image_features']) # doctest: +SKIP
-('batch', 'channel', 'height', 'width')
->>> print(train_set.axis_labels['vector_features']) # doctest: +SKIP
-('batch', 'feature')
->>> print(train_set.axis_labels['targets']) # doctest: +SKIP
-('batch', 'index')
+>>> print(train_set.axis_labels['image_features'])
+(u'batch', u'channel', u'height', u'width')
+>>> print(train_set.axis_labels['vector_features'])
+(u'batch', u'feature')
+>>> print(train_set.axis_labels['targets'])
+(u'batch', u'index')
 
 We can request data as usual:
 
@@ -294,8 +294,8 @@ what you requested, and nothing more.
 ...     'dataset.hdf5', which_set='train', subset=slice(0, 80),
 ...     sources=['vector_features'], load_in_memory=True)
 >>> data, = in_memory_train_vector_features.data_sources
->>> print(type(data)) # doctest: +SKIP
-<type 'numpy.ndarray'>
+>>> print(type(data)) # doctest: +ELLIPSIS
+<... 'numpy.ndarray'>
 >>> print(data.shape)
 (80, 10)
 

--- a/docs/new_dataset.rst
+++ b/docs/new_dataset.rst
@@ -298,9 +298,9 @@ You can now use the Iris dataset like you would use any other built-in dataset:
     >>> from fuel.datasets.iris import Iris # doctest: +SKIP
     >>> train_set = Iris('train')
     >>> print(train_set.axis_labels['features'])
-    (u'batch', u'feature')
+    ('batch', 'feature')
     >>> print(train_set.axis_labels['targets'])
-    (u'batch', u'index')
+    ('batch', 'index')
     >>> handle = train_set.open()
     >>> data = train_set.get_data(handle, slice(0, 10))
     >>> print((data[0].shape, data[1].shape))

--- a/doctests/__init__.py
+++ b/doctests/__init__.py
@@ -14,7 +14,7 @@ from tests import skip_if_not_available
 
 
 class Py23DocChecker(OutputChecker):
-    """Single-source Python 2/3 output checker
+    """Single-source Python 2/3 output checker.
 
     For more information, see the `original blog post`_.
 

--- a/doctests/__init__.py
+++ b/doctests/__init__.py
@@ -24,9 +24,9 @@ class Py23DocChecker(OutputChecker):
 
     """
     def check_output(self, want, got, optionflags):
-        if sys.version_info[0] > 2:
-            want = re.sub("u'(.*?)'", "'\\1'", want)
-            want = re.sub('u"(.*?)"', '"\\1"', want)
+        if sys.version_info[0] < 3:
+            got = re.sub("u'(.*?)'", "'\\1'", got)
+            got = re.sub('u"(.*?)"', '"\\1"', got)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 

--- a/doctests/__init__.py
+++ b/doctests/__init__.py
@@ -7,12 +7,13 @@ import os
 import pkgutil
 import re
 import sys
+from doctest import OutputChecker
 
 import fuel
 from tests import skip_if_not_available
 
 
-class Py23DocChecker(doctest.OutputChecker):
+class Py23DocChecker(OutputChecker):
     """Single-source Python 2/3 output checker
 
     For more information, see the `original blog post`_.
@@ -20,6 +21,7 @@ class Py23DocChecker(doctest.OutputChecker):
     .. _original blog post:
        https://dirkjan.ochtman.nl/writing/2014/07/06/
        single-source-python-23-doctests.html
+
     """
     def check_output(self, want, got, optionflags):
         if sys.version_info[0] > 2:

--- a/doctests/__init__.py
+++ b/doctests/__init__.py
@@ -27,7 +27,7 @@ class Py23DocChecker(OutputChecker):
         if sys.version_info[0] < 3:
             got = re.sub("u'(.*?)'", "'\\1'", got)
             got = re.sub('u"(.*?)"', '"\\1"', got)
-        return doctest.OutputChecker.check_output(self, want, got, optionflags)
+        return OutputChecker.check_output(self, want, got, optionflags)
 
 
 def setup(testobj):


### PR DESCRIPTION
This allows to remove a bunch of `doctest: +SKIP` statements and improve overall test coverage.

Fixes #87.