### PR TITLE
Automatic tagging of fuel-generated HDF5 files

### DIFF
--- a/bin/fuel-convert
+++ b/bin/fuel-convert
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     h5file = h5py.File(args.output_file, 'a')
     interface_version = H5PYDataset.interface_version.encode('utf-8')
     h5file.attrs['h5py_interface_version'] = interface_version
-    fuel_convert_version = converters.module_version.encode('utf-8')
+    fuel_convert_version = converters.__version__.encode('utf-8')
     h5file.attrs['fuel_convert_version'] = fuel_convert_version
     command = [os.path.basename(sys.argv[0])] + sys.argv[1:]
     h5file.attrs['fuel_convert_command'] = ' '.join(command).encode('utf-8')

--- a/bin/fuel-convert
+++ b/bin/fuel-convert
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 import argparse
 import os
+import sys
+
+import h5py
 
 from fuel import converters
+from fuel.datasets import H5PYDataset
 
 
 if __name__ == "__main__":
@@ -26,3 +30,15 @@ if __name__ == "__main__":
     args_dict = vars(args)
     func = args_dict.pop('func')
     func(**args_dict)
+
+    # Tag the newly-created file with H5PYDataset version and command-line
+    # options
+    h5file = h5py.File(args.output_file, 'a')
+    interface_version = H5PYDataset.interface_version.encode('utf-8')
+    h5file.attrs['h5py_interface_version'] = interface_version
+    fuel_convert_version = converters.module_version.encode('utf-8')
+    h5file.attrs['fuel_convert_version'] = fuel_convert_version
+    command = [os.path.basename(sys.argv[0])] + sys.argv[1:]
+    h5file.attrs['fuel_convert_command'] = ' '.join(command).encode('utf-8')
+    h5file.flush()
+    h5file.close()

--- a/bin/fuel-info
+++ b/bin/fuel-info
@@ -5,7 +5,7 @@ import os
 import h5py
 
 message_prefix = 'Metadata for {}'
-message = """
+message_body = """
 
     The command used to generate this file is
 
@@ -25,12 +25,12 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     with h5py.File(args.filename, 'r') as h5file:
-        interface_version = h5file.attrs['h5py_interface_version']
-        fuel_convert_version = h5file.attrs['fuel_convert_version']
-        fuel_convert_command = h5file.attrs['fuel_convert_command']
+        interface_version = h5file.attrs.get('h5py_interface_version', 'N/A')
+        fuel_convert_version = h5file.attrs.get('fuel_convert_version', 'N/A')
+        fuel_convert_command = h5file.attrs.get('fuel_convert_command', 'N/A')
 
     message_prefix = message_prefix.format(os.path.basename(args.filename))
-    message_body = message.format(
+    message_body = message_body.format(
         fuel_convert_command, interface_version, fuel_convert_version)
     message = ''.join(['\n', message_prefix, '\n', '=' * len(message_prefix),
                        message_body])

--- a/bin/fuel-info
+++ b/bin/fuel-info
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+import argparse
+import os
+
+import h5py
+
+message_prefix = 'Metadata for {}'
+message = """
+
+    The command used to generate this file is
+
+        {}
+
+    Relevant versions are
+
+        H5PYDataset     {}
+        fuel.converters {}
+"""
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Extracts metadata from a Fuel-converted HDF5 file.')
+    parser.add_argument("filename", help="HDF5 file to analyze")
+    args = parser.parse_args()
+
+    with h5py.File(args.filename, 'r') as h5file:
+        interface_version = h5file.attrs['h5py_interface_version']
+        fuel_convert_version = h5file.attrs['fuel_convert_version']
+        fuel_convert_command = h5file.attrs['fuel_convert_command']
+
+    message_prefix = message_prefix.format(os.path.basename(args.filename))
+    message_body = message.format(
+        fuel_convert_command, interface_version, fuel_convert_version)
+    message = ''.join(['\n', message_prefix, '\n', '=' * len(message_prefix),
+                       message_body])
+    print(message)

--- a/fuel/converters/__init__.py
+++ b/fuel/converters/__init__.py
@@ -14,6 +14,7 @@ from fuel.converters import binarized_mnist
 from fuel.converters import cifar10
 from fuel.converters import mnist
 
+module_version = '0.1'
 all_converters = (
     ('binarized_mnist', binarized_mnist.fill_subparser),
     ('cifar10', cifar10.fill_subparser),

--- a/fuel/converters/__init__.py
+++ b/fuel/converters/__init__.py
@@ -14,7 +14,7 @@ from fuel.converters import binarized_mnist
 from fuel.converters import cifar10
 from fuel.converters import mnist
 
-module_version = '0.1'
+__version__ = '0.1'
 all_converters = (
     ('binarized_mnist', binarized_mnist.fill_subparser),
     ('cifar10', cifar10.fill_subparser),

--- a/fuel/datasets/hdf5.py
+++ b/fuel/datasets/hdf5.py
@@ -124,6 +124,7 @@ class H5PYDataset(Dataset):
         indices are ordered.
 
     """
+    interface_version = '0.1'
     _ref_counts = defaultdict(int)
     _file_handles = {}
 

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=['six', 'picklable_itertools', 'toolz', 'pyyaml', 'h5py',
                       'tables', 'urllib3', 'certifi'],
-    scripts=['bin/fuel-convert', 'bin/fuel-download']
+    scripts=['bin/fuel-convert', 'bin/fuel-download', 'bin/fuel-info']
 )


### PR DESCRIPTION
Fixes #72.

This PR aims at introducing a way to keep trace of how an HDF5 was created using Fuel. It introduces a `interface_version` class attribute in the `H5PYDataset` class which needs to be changed every time the interface changes. It also introduces three attributes tagged in each file `fuel-convert` creates:

* `h5py_interface_version`: self-explanatory
* `fuel_version`: self-explanatory
* `fuel_convert_args`: which command-line arguments were passed to `fuel-convert` in order to create this dataset