### PR TITLE
Add downloading script for Travis

### DIFF
--- a/.travis-data.sh
+++ b/.travis-data.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Download and convert given datasets if not present already
+# Usage: .travis-download.sh [dataset ...]
+set -ev
+
+function download {
+  if [ ! -f $FUEL_DATA_PATH/$1.hdf5 ]; then
+    fuel-download $1
+    fuel-convert $1
+    fuel-download --clear $1
+  fi
+}
+
+cd $FUEL_DATA_PATH
+
+for dataset in "$@"; do
+  download $dataset
+done
+
+cd -

--- a/.travis-data.sh
+++ b/.travis-data.sh
@@ -7,7 +7,7 @@ function download {
   if [ ! -f $FUEL_DATA_PATH/$1.hdf5 ]; then
     fuel-download $1
     fuel-convert $1
-    fuel-download --clear $1
+    fuel-download $1 --clear
   fi
 }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,32 +24,7 @@ install:
 script:
   - pip install . -r requirements.txt
   # Download and process binarized MNIST for tests if not loaded from cache
-  - |
-      if [ ! -f $FUEL_DATA_PATH/binarized_mnist.hdf5 ]; then
-        cd $FUEL_DATA_PATH
-        fuel-download binarized_mnist
-        fuel-convert binarized_mnist
-        fuel-download --clear binarized_mnist
-        cd -
-      fi
-  # Download and process MNIST for tests if not loaded from cache
-  - |
-      if [ ! -f $FUEL_DATA_PATH/mnist.hdf5 ]; then
-        cd $FUEL_DATA_PATH
-        fuel-download mnist
-        fuel-convert mnist
-        fuel-download --clear mnist
-        cd -
-      fi
-  # Download and process CIFAR10 for tests if not loaded from cache
-  - |
-      if [ ! -f $FUEL_DATA_PATH/cifar10.hdf5 ]; then
-        cd $FUEL_DATA_PATH
-        fuel-download cifar10
-        fuel-convert cifar10
-        fuel-download --clear cifar10
-        cd -
-      fi
+  - ./.travis-data.sh mnist binarized_mnist cifar10
   # With Fuel installed we can install Blocks
   - pip install -e git+git://github.com/bartvm/blocks.git#egg=blocks[test,plot] --src=$HOME -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt
   # Run the Blocks test to make sure we didn't break anything


### PR DESCRIPTION
Factored out the downloading logic for Travis. This way we can re-use the script to download datasets on Travis for blocks, blocks-extras, blocks-examples, etc.