### PR TITLE
Downloaders refactor & non-public URL support

### DIFF
--- a/bin/fuel-download
+++ b/bin/fuel-download
@@ -21,4 +21,10 @@ if __name__ == "__main__":
             name, parents=[parent_parser],
             help='Download the {} dataset'.format(name)))
     args = parser.parse_args()
-    args.func(args)
+    args_dict = vars(args)
+    try:
+        func = args_dict.pop('func')
+    except KeyError:
+        parser.print_usage()
+        parser.exit()
+    func(**args_dict)

--- a/bin/fuel-download
+++ b/bin/fuel-download
@@ -3,7 +3,14 @@ import argparse
 import os
 
 from fuel import downloaders
+from fuel.downloaders.base import NeedURLPrefix
 
+url_prefix_message = """
+Some files for this dataset do not have a download URL.
+
+Provide a URL prefix with --url-prefix to prepend to the filenames,
+e.g. http://path.to/files/
+""".strip()
 
 if __name__ == "__main__":
     built_in_datasets = dict(downloaders.all_downloaders)
@@ -27,4 +34,7 @@ if __name__ == "__main__":
     except KeyError:
         parser.print_usage()
         parser.exit()
-    func(**args_dict)
+    try:
+        func(**args_dict)
+    except NeedURLPrefix:
+        parser.error(url_prefix_message)

--- a/docs/new_dataset.rst
+++ b/docs/new_dataset.rst
@@ -255,7 +255,9 @@ You can now use the Iris dataset like you would use any other built-in dataset:
     >>> subparsers = parser.add_subparsers()
     >>> fill_downloader_subparser(subparsers.add_parser('iris'))
     >>> args = parser.parse_args(['iris'])
-    >>> args.func(args)
+    >>> args_dict = vars(args)
+    >>> func = args_dict.pop('func')
+    >>> func(**args_dict)
 
 .. doctest::
     :hide:

--- a/fuel/downloaders/base.py
+++ b/fuel/downloaders/base.py
@@ -44,26 +44,22 @@ def download(url, file_handle):
         shutil.copyfileobj(response, file_handle)
 
 
-def default_downloader(args):
+def default_downloader(directory, urls, filenames, clear=False):
     """Downloads or clears files from URLs and filenames.
-
-    This function takes an :class:`argparse.Namespace` instance as
-    argument and expects it to contain three attributes:
-
-    * `directory` : directory in which downloaded files are saved
-    * `urls` : list of URLs to download
-    * `filenames` : list of file names for the corresponding URLs
 
     Parameters
     ----------
-    args : :class:`argparse.Namespace`
-        Parsed command line arguments
+    directory : str
+        The directory in which downloaded files are saved.
+    urls : list
+        A list of URLs to download.
+    filenames : list
+        A list of file names for the corresponding URLs.
+    clear : bool, optional
+        If `True`, delete the given filenames from the given
+        directory rather than download them.
 
     """
-    urls = args.urls
-    save_directory = args.directory
-    filenames = args.filenames
-
     # Parse file names from URL if not provided
     for i, url in enumerate(urls):
         filename = filenames[i]
@@ -72,9 +68,9 @@ def default_downloader(args):
         if not filename:
             raise ValueError("no filename available for URL '{}'".format(url))
         filenames[i] = filename
-    files = [os.path.join(save_directory, f) for f in filenames]
+    files = [os.path.join(directory, f) for f in filenames]
 
-    if args.clear:
+    if clear:
         for f in files:
             if os.path.isfile(f):
                 os.remove(f)

--- a/fuel/downloaders/base.py
+++ b/fuel/downloaders/base.py
@@ -6,6 +6,11 @@ import urllib3
 from urllib3.util.url import parse_url
 
 
+class NeedURLPrefix(Exception):
+    """Raised when a URL is not provided for a file."""
+    pass
+
+
 def filename_from_url(url, path=None):
     """Parses a URL to determine a file name.
 
@@ -44,7 +49,8 @@ def download(url, file_handle):
         shutil.copyfileobj(response, file_handle)
 
 
-def default_downloader(directory, urls, filenames, clear=False):
+def default_downloader(directory, urls, filenames, url_prefix=None,
+                       clear=False):
     """Downloads or clears files from URLs and filenames.
 
     Parameters
@@ -55,6 +61,9 @@ def default_downloader(directory, urls, filenames, clear=False):
         A list of URLs to download.
     filenames : list
         A list of file names for the corresponding URLs.
+    url_prefix : str, optional
+        If provided, this is prepended to filenames that
+        lack a corresponding URL.
     clear : bool, optional
         If `True`, delete the given filenames from the given
         directory rather than download them.
@@ -76,5 +85,9 @@ def default_downloader(directory, urls, filenames, clear=False):
                 os.remove(f)
     else:
         for url, f in zip(urls, files):
+            if not url:
+                if url_prefix is None:
+                    raise NeedURLPrefix
+                url = url_prefix + filename
             with open(f, 'wb') as file_handle:
                 download(url, file_handle)

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -81,7 +81,6 @@ class TestDefaultDownloader(object):
         with open(iris_path, 'r') as f:
             assert hashlib.md5(
                 f.read().encode('utf-8')).hexdigest() == iris_hash
-        os.remove(iris_path)
 
     def test_default_downloader_save_no_filename(self):
         iris_path = os.path.join(self.tempdir, 'iris.data')
@@ -91,7 +90,6 @@ class TestDefaultDownloader(object):
         with open(iris_path, 'r') as f:
             assert hashlib.md5(
                 f.read().encode('utf-8')).hexdigest() == iris_hash
-        os.remove(iris_path)
 
     def test_default_downloader_save_no_url_url_prefix(self):
         iris_path = os.path.join(self.tempdir, 'iris.data')

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -4,21 +4,15 @@ import os
 import shutil
 import tempfile
 
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_raises
 
 from fuel.downloaders import mnist, binarized_mnist, cifar10
 from fuel.downloaders.base import (download, default_downloader,
-                                   filename_from_url)
+                                   filename_from_url, NeedURLPrefix)
 
 iris_url = ('https://archive.ics.uci.edu/ml/machine-learning-databases/' +
             'iris/iris.data')
 iris_hash = "42615765a885ddf54427f12c34a0a070"
-
-
-class DummyArgs:
-    def __init__(self, **kwargs):
-        for key, val in kwargs.items():
-            setattr(self, key, val)
 
 
 def test_filename_from_url():
@@ -81,9 +75,9 @@ class TestDefaultDownloader(object):
 
     def test_default_downloader_save_with_filename(self):
         iris_path = os.path.join(self.tempdir, 'iris.data')
-        args = DummyArgs(directory=self.tempdir, clear=False, urls=[iris_url],
-                         filenames=['iris.data'])
-        default_downloader(args)
+        args = dict(directory=self.tempdir, clear=False, urls=[iris_url],
+                    filenames=['iris.data'])
+        default_downloader(**args)
         with open(iris_path, 'r') as f:
             assert hashlib.md5(
                 f.read().encode('utf-8')).hexdigest() == iris_hash
@@ -91,9 +85,9 @@ class TestDefaultDownloader(object):
 
     def test_default_downloader_save_no_filename(self):
         iris_path = os.path.join(self.tempdir, 'iris.data')
-        args = DummyArgs(directory=self.tempdir, clear=False, urls=[iris_url],
-                         filenames=[None])
-        default_downloader(args)
+        args = dict(directory=self.tempdir, clear=False, urls=[iris_url],
+                    filenames=[None])
+        default_downloader(**args)
         with open(iris_path, 'r') as f:
             assert hashlib.md5(
                 f.read().encode('utf-8')).hexdigest() == iris_hash
@@ -102,7 +96,7 @@ class TestDefaultDownloader(object):
     def test_default_downloader_clear(self):
         file_path = os.path.join(self.tempdir, 'tmp.data')
         open(file_path, 'a').close()
-        args = DummyArgs(directory=self.tempdir, clear=True, urls=[None],
-                         filenames=['tmp.data'])
-        default_downloader(args)
+        args = dict(directory=self.tempdir, clear=True, urls=[None],
+                    filenames=['tmp.data'])
+        default_downloader(**args)
         assert not os.path.isfile(file_path)

--- a/tests/test_downloaders.py
+++ b/tests/test_downloaders.py
@@ -93,6 +93,20 @@ class TestDefaultDownloader(object):
                 f.read().encode('utf-8')).hexdigest() == iris_hash
         os.remove(iris_path)
 
+    def test_default_downloader_save_no_url_url_prefix(self):
+        iris_path = os.path.join(self.tempdir, 'iris.data')
+        args = dict(directory=self.tempdir, clear=False, urls=[None],
+                    filenames=['iris.data'], url_prefix=iris_url[:-9])
+        default_downloader(**args)
+        with open(iris_path, 'r') as f:
+            assert hashlib.md5(
+                f.read().encode('utf-8')).hexdigest() == iris_hash
+
+    def test_default_downloader_save_no_url_no_url_prefix(self):
+        args = dict(directory=self.tempdir, clear=False, urls=[None],
+                    filenames=['iris.data'])
+        assert_raises(NeedURLPrefix, default_downloader, **args)
+
     def test_default_downloader_clear(self):
         file_path = os.path.join(self.tempdir, 'tmp.data')
         open(file_path, 'a').close()


### PR DESCRIPTION
* Refactor downloaders in the same way that converters was recently refactored.
* Allow specification of url_prefix to default_downloader.
* Incidentally also fix a similar error to #114's target.